### PR TITLE
Authentication layer: JWT login and protected endpoints

### DIFF
--- a/src/Challengers.Api/Challengers.Api.csproj
+++ b/src/Challengers.Api/Challengers.Api.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>7addd514-4322-4d39-91b8-3c62e4ec3394</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Challengers.Api/Contracts/Auth/LoginRequest.cs
+++ b/src/Challengers.Api/Contracts/Auth/LoginRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace Challengers.Api.Contracts.Auth;
+
+public class LoginRequest
+{
+    public string Username { get; set; } = default!;
+    public string Password { get; set; } = default!;
+}

--- a/src/Challengers.Api/Contracts/Auth/LoginResponse.cs
+++ b/src/Challengers.Api/Contracts/Auth/LoginResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace Challengers.Api.Contracts.Auth;
+
+public class LoginResponse
+{
+    public string Token { get; set; } = default!;
+    public DateTime ExpiresAt { get; set; }
+}
+

--- a/src/Challengers.Api/Controllers/AuthController.cs
+++ b/src/Challengers.Api/Controllers/AuthController.cs
@@ -1,0 +1,39 @@
+﻿using Challengers.Api.Contracts.Auth;
+using Challengers.Infrastructure.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Challengers.Api.Controllers;
+
+[ApiController]
+[Route("auth")]
+public class AuthController(JwtTokenGenerator tokenGenerator, IConfiguration configuration) : ControllerBase
+{
+    private readonly JwtTokenGenerator _tokenGenerator = tokenGenerator;
+    private readonly IConfiguration _configuration = configuration;
+
+    [AllowAnonymous]
+    [HttpPost]
+    public IActionResult Login([FromBody] LoginRequest request)
+    {
+        var adminUsername = _configuration["AdminCredentials:Username"];
+        var adminPassword = _configuration["AdminCredentials:Password"];
+
+        Console.WriteLine($"Expected: {adminUsername} / {adminPassword}");
+        Console.WriteLine($"Received: {request.Username} / {request.Password}");
+
+        if (request.Username != adminUsername || request.Password != adminPassword)
+            return Unauthorized("Invalid credentials");
+
+        var token = _tokenGenerator.GenerateToken(request.Username);
+        var expiresAt = DateTime.UtcNow.AddMinutes(
+            int.Parse(_configuration["JwtSettings:ExpirationMinutes"] ?? "60")
+        );
+
+        return Ok(new LoginResponse
+        {
+            Token = token,
+            ExpiresAt = expiresAt
+        });
+    }
+}

--- a/src/Challengers.Api/Controllers/PlayersController.cs
+++ b/src/Challengers.Api/Controllers/PlayersController.cs
@@ -5,6 +5,7 @@ using Challengers.Application.Features.Players.Commands.UpdatePlayer;
 using Challengers.Application.Features.Players.Queries.GetPlayerById;
 using Challengers.Application.Features.Players.Queries.GetPlayers;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Challengers.Api.Controllers;
@@ -14,7 +15,8 @@ namespace Challengers.Api.Controllers;
 public class PlayersController(IMediator mediator) : ControllerBase
 {
     private readonly IMediator _mediator = mediator;
-
+    
+    [AllowAnonymous]
     [HttpGet("{id}")]
     public async Task<ActionResult<PlayerDto>> Get(Guid id, CancellationToken cancellationToken)
     {
@@ -43,6 +45,7 @@ public class PlayersController(IMediator mediator) : ControllerBase
         return NoContent();
     }
 
+    [AllowAnonymous]
     [HttpGet]
     public async Task<ActionResult<PagedResultDto<PlayerDto>>> GetAll(
         [FromQuery] GetPlayersQueryDto dto,

--- a/src/Challengers.Api/Controllers/TournamentsController.cs
+++ b/src/Challengers.Api/Controllers/TournamentsController.cs
@@ -4,6 +4,7 @@ using Challengers.Application.Features.Tournaments.Commands.SimulateTournament;
 using Challengers.Application.Features.Tournaments.Queries.GetTournamentResult;
 using Challengers.Application.Features.Tournaments.Queries.GetTournamentsByFilter;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Challengers.Api.Controllers;
@@ -28,6 +29,7 @@ public class TournamentsController(IMediator mediator) : ControllerBase
         return Ok(result);
     }
 
+    [AllowAnonymous]
     [HttpGet("{id}")]
     public async Task<ActionResult<TournamentResultDto>> GetById(Guid id, CancellationToken cancellationToken)
     {
@@ -35,6 +37,7 @@ public class TournamentsController(IMediator mediator) : ControllerBase
         return Ok(result);
     }
 
+    [AllowAnonymous]
     [HttpGet]
     public async Task<ActionResult<List<TournamentResultDto>>> GetAll(
     [FromQuery] GetTournamentsQueryDto dto,
@@ -43,5 +46,4 @@ public class TournamentsController(IMediator mediator) : ControllerBase
         var result = await _mediator.Send(new GetTournamentsByFilterQuery(dto), cancellationToken);
         return Ok(result);
     }
-
 }

--- a/src/Challengers.Api/Program.cs
+++ b/src/Challengers.Api/Program.cs
@@ -1,76 +1,163 @@
-﻿using Challengers.Application.Features.Players.Commands.CreatePlayer;
+﻿using Challengers.Api.Middleware;
+using Challengers.Application.Behaviors;
 using Challengers.Application.Features.Tournaments.Commands.CreateTournament;
+using Challengers.Application.Validators;
+using Challengers.Infrastructure.Auth;
 using Challengers.Infrastructure.DependencyInjection;
 using Challengers.Infrastructure.Persistence;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.OpenApi.Models;
 using FluentValidation;
-using Challengers.Application.Behaviors;
-using MediatR;
-using Challengers.Api.Middleware;
 using FluentValidation.AspNetCore;
-using Challengers.Application.Validators;
-using Challengers.Api.Swagger;
+using MediatR;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+using System.Text;
 
-var builder = WebApplication.CreateBuilder(args);
+namespace Challengers.Api;
 
-builder.WebHost.ConfigureKestrel(serverOptions =>
+public class Program
 {
-    serverOptions.ListenAnyIP(80);
-});
+    private static readonly string[] JwtBearerSchemes = ["Bearer"];
 
-builder.Configuration
-    .SetBasePath(Directory.GetCurrentDirectory())
-    .AddJsonFile("appsettings.json")
-    .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true)
-    .AddEnvironmentVariables();
-
-var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
-
-builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
-
-builder.Services.AddDbContext<ChallengersDbContext>(options =>
-{
-    options.UseSqlServer(connectionString, sql =>
+    public static void Main(string[] args)
     {
-        sql.EnableRetryOnFailure();
-    });
-});
+        var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddMediatR(cfg =>
-    cfg.RegisterServicesFromAssemblyContaining<CreateTournamentCommand>());
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.ListenAnyIP(80);
+        });
 
-builder.Services.AddControllers();
+        builder.Configuration
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json")
+            .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true)
+            .AddEnvironmentVariables();
 
-builder.Services.AddInfrastructureServices();
-builder.Services.AddFluentValidationAutoValidation();
-builder.Services.AddValidatorsFromAssemblyContaining<CreateTournamentRequestDtoValidator>();
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen(c =>
-{
-    c.SchemaFilter<GenderEnumSchemaFilter>();
-    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Challengers API", Version = "v1" });
-});
+        var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
 
-var app = builder.Build();
+        builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
 
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Challengers API v1"));
+        builder.Services.AddDbContext<ChallengersDbContext>(options =>
+        {
+            options.UseSqlServer(connectionString, sql =>
+            {
+                sql.EnableRetryOnFailure();
+            });
+        });
+
+        builder.Services.AddMediatR(cfg =>
+            cfg.RegisterServicesFromAssemblyContaining<CreateTournamentCommand>());
+
+        builder.Services.AddControllers(options =>
+        {
+            options.Filters.Add(new AuthorizeFilter(new AuthorizationPolicyBuilder()
+                .RequireAuthenticatedUser()
+                .Build()));
+        });
+
+        builder.Services.AddInfrastructureServices();
+        builder.Services.AddFluentValidationAutoValidation();
+        builder.Services.AddValidatorsFromAssemblyContaining<CreateTournamentRequestDtoValidator>();
+        builder.Services.AddEndpointsApiExplorer();
+        builder.Services.AddSwaggerGen(c =>
+        {
+            c.SwaggerDoc("v1", new OpenApiInfo { Title = "Challengers", Version = "v1" });
+
+            var securityScheme = new OpenApiSecurityScheme
+            {
+                Name = "Authorization",
+                Type = SecuritySchemeType.Http,
+                Scheme = "bearer",
+                BearerFormat = "JWT",
+                In = ParameterLocation.Header,
+                Description = "Enter JWT token",
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            };
+
+            c.AddSecurityDefinition("Bearer", securityScheme);
+            c.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                { securityScheme, JwtBearerSchemes }
+            });
+        });
+
+        builder.Services.Configure<JwtSettings>(builder.Configuration.GetSection("JwtSettings"));
+
+        var jwtSettings = ValidateJwtSettings(builder);
+
+        builder.Services.AddAuthentication(options =>
+        {
+            options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+        })
+        .AddJwtBearer(options =>
+        {
+            options.RequireHttpsMetadata = true;
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidIssuer = jwtSettings.Issuer,
+                ValidateAudience = true,
+                ValidAudience = jwtSettings.Audience,
+                ValidateLifetime = true,
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings.Key)),
+                ValidateIssuerSigningKey = true
+            };
+        });
+
+        builder.Services.AddAuthorization();
+
+        var app = builder.Build();
+
+        if (app.Environment.IsDevelopment())
+        {
+            app.UseSwagger();
+            app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Challengers API v1"));
+        }
+
+        app.UseHttpsRedirection();
+        app.UseMiddleware<ExceptionHandlingMiddleware>();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.MapControllers();
+        app.MapGet("/ping", () => Results.Ok("pong"));
+
+        if (app.Environment.IsDevelopment() || app.Environment.IsStaging())
+        {
+            using var scope = app.Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ChallengersDbContext>();
+            db.Database.Migrate();
+        }
+
+        app.Run();
+    }
+    private static JwtSettings ValidateJwtSettings(WebApplicationBuilder builder)
+    {
+        var jwtSettings = builder.Configuration.GetSection("JwtSettings").Get<JwtSettings>();
+
+        if (jwtSettings == null)
+            throw new InvalidOperationException("JwtSettings section is missing.");
+
+        if (string.IsNullOrWhiteSpace(jwtSettings.Key))
+            throw new InvalidOperationException("JwtSettings:Key is missing.");
+
+        if (string.IsNullOrWhiteSpace(jwtSettings.Issuer))
+            throw new InvalidOperationException("JwtSettings:Issuer is missing.");
+
+        if (string.IsNullOrWhiteSpace(jwtSettings.Audience))
+            throw new InvalidOperationException("JwtSettings:Audience is missing.");
+
+        if (jwtSettings.ExpirationMinutes <= 0)
+            throw new InvalidOperationException("JwtSettings:ExpirationMinutes must be greater than 0.");
+
+        return jwtSettings;
+    }
 }
-
-app.UseHttpsRedirection();
-app.UseMiddleware<ExceptionHandlingMiddleware>();
-app.UseAuthorization();
-app.MapControllers();
-app.MapGet("/ping", () => Results.Ok("pong"));
-
-if (app.Environment.IsDevelopment() || app.Environment.IsStaging())
-{
-    using var scope = app.Services.CreateScope();
-    var db = scope.ServiceProvider.GetRequiredService<ChallengersDbContext>();
-    db.Database.Migrate();
-}
-
-app.Run();

--- a/src/Challengers.Api/appsettings.Development.json
+++ b/src/Challengers.Api/appsettings.Development.json
@@ -7,5 +7,9 @@
   },
   "ConnectionStrings": {
     "DefaultConnection": "Server=db,1433;Database=ChallengersDb;User=sa;Password=MyS3cur3P@ss!;TrustServerCertificate=True;"
+  },
+  "AdminCredentials": {
+    "Username": "admin",
+    "Password": "SuperSecurePassword123"
   }
 }

--- a/src/Challengers.Api/appsettings.json
+++ b/src/Challengers.Api/appsettings.json
@@ -8,5 +8,11 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=db,1433;Database=ChallengersDb;User=sa;Password=MyS3cur3P@ss!;TrustServerCertificate=True;"
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "JwtSettings": {
+    "Key": "THIS_SHOULD_BE_REPLACED_BY_A_SECURE_KEY",
+    "Issuer": "ChallengersApi",
+    "Audience": "ChallengersApiUsers",
+    "ExpirationMinutes": 60
+  }
 }

--- a/src/Challengers.Infrastructure/Auth/JwtSettings.cs
+++ b/src/Challengers.Infrastructure/Auth/JwtSettings.cs
@@ -1,0 +1,9 @@
+﻿namespace Challengers.Infrastructure.Auth;
+
+public class JwtSettings
+{
+    public string Key { get; set; } = default!;
+    public string Issuer { get; set; } = default!;
+    public string Audience { get; set; } = default!;
+    public int ExpirationMinutes { get; set; }
+}

--- a/src/Challengers.Infrastructure/Auth/JwtTokenGenerator.cs
+++ b/src/Challengers.Infrastructure/Auth/JwtTokenGenerator.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace Challengers.Infrastructure.Auth;
+
+public class JwtTokenGenerator(IOptions<JwtSettings> options)
+{
+    private readonly JwtSettings _settings = options.Value;
+
+    public string GenerateToken(string username)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_settings.Key));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Name, username),
+            new Claim(ClaimTypes.Role, "Admin")
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: _settings.Issuer,
+            audience: _settings.Audience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(_settings.ExpirationMinutes),
+            signingCredentials: creds
+        );
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}
+


### PR DESCRIPTION
Implements the authentication layer using JWT bearer tokens, enabling protected access to player and tournament management operations.

## Includes:

- AuthController with /login endpoint for credential-based authentication
- JWT token generation via JwtTokenGenerator and JwtSettings configuration
- Bearer token setup in Program.cs using Microsoft.AspNetCore.Authentication.JwtBearer
- Secure write operations on PlayersController and TournamentsController using [Authorize]
- Swagger integration with default bearer token support
- Separation of contract models for authentication (LoginRequest, LoginResponse)

## Additional features:

- Login credentials bound to appsettings.json (environment-specific)
- Token expiration configurable via settings
- Clean authentication configuration through infrastructure layer
- Modular structure to support future user registration or admin seeding

Ready for integration testing with protected endpoints.
Only authenticated requests can create, update or delete players and tournaments.