### PR TITLE
Tests & refactors: domain coverage, handler logic and pagination

### DIFF
--- a/Challengers.sln
+++ b/Challengers.sln
@@ -15,6 +15,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Challengers.Infrastructure"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Challengers.Shared", "src\Challengers.Shared\Challengers.Shared.csproj", "{0CAE77BA-6A71-897C-D232-C8BA459C197C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Challengers.UnitTests", "tests\Challengers.UnitTests\Challengers.UnitTests.csproj", "{78D9AB10-83F8-D824-0043-9753531477E4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -85,6 +89,18 @@ Global
 		{0CAE77BA-6A71-897C-D232-C8BA459C197C}.Release|x64.Build.0 = Release|Any CPU
 		{0CAE77BA-6A71-897C-D232-C8BA459C197C}.Release|x86.ActiveCfg = Release|Any CPU
 		{0CAE77BA-6A71-897C-D232-C8BA459C197C}.Release|x86.Build.0 = Release|Any CPU
+		{78D9AB10-83F8-D824-0043-9753531477E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{78D9AB10-83F8-D824-0043-9753531477E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78D9AB10-83F8-D824-0043-9753531477E4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{78D9AB10-83F8-D824-0043-9753531477E4}.Debug|x64.Build.0 = Debug|Any CPU
+		{78D9AB10-83F8-D824-0043-9753531477E4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{78D9AB10-83F8-D824-0043-9753531477E4}.Debug|x86.Build.0 = Debug|Any CPU
+		{78D9AB10-83F8-D824-0043-9753531477E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{78D9AB10-83F8-D824-0043-9753531477E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{78D9AB10-83F8-D824-0043-9753531477E4}.Release|x64.ActiveCfg = Release|Any CPU
+		{78D9AB10-83F8-D824-0043-9753531477E4}.Release|x64.Build.0 = Release|Any CPU
+		{78D9AB10-83F8-D824-0043-9753531477E4}.Release|x86.ActiveCfg = Release|Any CPU
+		{78D9AB10-83F8-D824-0043-9753531477E4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -95,6 +111,7 @@ Global
 		{45C5DA4A-F75D-4431-9FAF-29BD81A8A118} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{5D32297C-2B9D-42EA-9B4B-3E80632DB2AE} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{0CAE77BA-6A71-897C-D232-C8BA459C197C} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{78D9AB10-83F8-D824-0043-9753531477E4} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CB7C1265-5750-4FAB-8828-E49C76C4059E}

--- a/src/Challengers.Application/Features/Players/Commands/UpdatePlayer/UpdatePlayerHandler.cs
+++ b/src/Challengers.Application/Features/Players/Commands/UpdatePlayer/UpdatePlayerHandler.cs
@@ -3,6 +3,7 @@ using Challengers.Domain.Entities;
 using Challengers.Domain.Enums;
 using Challengers.Shared.Helpers;
 using MediatR;
+using System;
 
 namespace Challengers.Application.Features.Players.Commands.UpdatePlayer;
 
@@ -26,7 +27,7 @@ public class UpdatePlayerHandler(IPlayerRepository repository) : IRequestHandler
                 _ => throw new ArgumentException(ErrorMessages.InvalidGender())
             };
 
-            replacement.ForceSetId(existing.Id);
+            typeof(Player).GetProperty(nameof(Player.Id))!.SetValue(replacement, existing.Id);
 
             await _repository.ReplaceAsync(replacement, cancellationToken);
         }

--- a/src/Challengers.Application/Features/Players/Queries/GetPlayers/GetPlayersQueryHandler.cs
+++ b/src/Challengers.Application/Features/Players/Queries/GetPlayers/GetPlayersQueryHandler.cs
@@ -11,11 +11,17 @@ public class GetPlayersQueryHandler(IPlayerRepository repository) : IRequestHand
 
     public async Task<PagedResultDto<PlayerDto>> Handle(GetPlayersQuery request, CancellationToken cancellationToken)
     {
-        var result = await _repository.GetFilteredAsync(request.Dto, cancellationToken);
+        var players = await _repository.GetFilteredAsync(request.Dto, cancellationToken);
 
-        return new PagedResultDto<PlayerDto>
-        {
-            Items = [.. result.Items.Select(p => new PlayerDto
+        var totalCount = players.Count;
+
+        var page = request.Dto.Page ?? DefaultPage;
+        var pageSize = request.Dto.PageSize ?? DefaultPageSize;
+
+        var pagedItems = players
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(p => new PlayerDto
             {
                 Id = p.Id,
                 Name = p.Name,
@@ -25,10 +31,13 @@ public class GetPlayersQueryHandler(IPlayerRepository repository) : IRequestHand
                 Speed = p is MalePlayer m2 ? m2.Speed : null,
                 ReactionTime = p is FemalePlayer f ? f.ReactionTime : null,
                 Gender = p.Gender
-            })],
-            TotalCount = result.TotalCount,
-            Page = result.Page,
-            PageSize = result.PageSize
+            })
+            .ToList();
+
+        return new PagedResultDto<PlayerDto>
+        {
+            TotalCount = totalCount,
+            Items = pagedItems
         };
     }
 

--- a/src/Challengers.Application/Features/Tournaments/Commands/CreateTournament/CreateTournamentHandler.cs
+++ b/src/Challengers.Application/Features/Tournaments/Commands/CreateTournament/CreateTournamentHandler.cs
@@ -4,6 +4,7 @@ using Challengers.Domain.Entities;
 using Challengers.Domain.Enums;
 using Challengers.Shared.Helpers;
 using MediatR;
+using System.Collections.Generic;
 
 namespace Challengers.Application.Features.Tournaments.Commands.CreateTournament;
 

--- a/src/Challengers.Application/Features/Tournaments/Commands/SimulateTournament/SimulateTournamentHandler.cs
+++ b/src/Challengers.Application/Features/Tournaments/Commands/SimulateTournament/SimulateTournamentHandler.cs
@@ -12,7 +12,7 @@ public class SimulateTournamentHandler(
 
     public async Task<SimulateTournamentResponseDto> Handle(SimulateTournamentCommand request, CancellationToken cancellationToken)
     {
-        var tournament = await _tournamentRepository.GetWithDetailsAsync(request.TournamentId, cancellationToken) ?? throw new KeyNotFoundException(GetMessage(TournamentNotFound));
+        var tournament = await _tournamentRepository.GetWithDetailsAsync(request.TournamentId, cancellationToken) ?? throw new KeyNotFoundException(FormatMessage(TournamentNotFound, request.TournamentId));
         
         if (tournament.Winner is not null || tournament.Matches.Count != 0)
         {

--- a/src/Challengers.Application/Features/Tournaments/Queries/GetTournamentResult/GetTournamentResultHandler.cs
+++ b/src/Challengers.Application/Features/Tournaments/Queries/GetTournamentResult/GetTournamentResultHandler.cs
@@ -15,7 +15,7 @@ public class GetTournamentResultHandler(
         var tournament = await _tournamentRepository.GetWithDetailsAsync(request.TournamentId, cancellationToken);
 
         return tournament is null
-            ? throw new KeyNotFoundException(GetMessage(TournamentNotFound))
+            ? throw new KeyNotFoundException(FormatMessage(TournamentNotFound, request.TournamentId))
             : new TournamentResultDto
         {
             Id = tournament.Id,

--- a/src/Challengers.Application/Features/Tournaments/Queries/GetTournamentsByFilter/GetTournamentsByFilterHandler.cs
+++ b/src/Challengers.Application/Features/Tournaments/Queries/GetTournamentsByFilter/GetTournamentsByFilterHandler.cs
@@ -1,26 +1,43 @@
 ﻿using Challengers.Application.DTOs;
 using Challengers.Application.Interfaces.Persistence;
 using MediatR;
+using System.Linq;
 
 namespace Challengers.Application.Features.Tournaments.Queries.GetTournamentsByFilter;
 
-public class GetTournamentsByFilterHandler(ITournamentRepository repository)
-    : IRequestHandler<GetTournamentsByFilterQuery, List<TournamentResultDto>>
+public class GetTournamentsByFilterHandler(ITournamentRepository repository) : IRequestHandler<GetTournamentsByFilterQuery, PagedResultDto<TournamentResultDto>>
 {
     private readonly ITournamentRepository _repository = repository;
 
-    public async Task<List<TournamentResultDto>> Handle(GetTournamentsByFilterQuery request, CancellationToken cancellationToken)
+    public async Task<PagedResultDto<TournamentResultDto>> Handle(
+    GetTournamentsByFilterQuery request,
+    CancellationToken cancellationToken)
     {
         var tournaments = await _repository.GetFilteredAsync(request.Dto, cancellationToken);
 
-        return [.. tournaments.Select(t => new TournamentResultDto
-        {
-            Id = t.Id,
-            Name = t.Name,
-            Gender = t.Gender,
-            CreatedAt = t.CreatedAt,
-            Winner = t.Winner?.GetFullName() ?? "-"
-        })];
+        var totalCount = tournaments.Count;
 
+        var page = request.Dto.Page ?? DefaultPage;
+        var pageSize = request.Dto.PageSize ?? DefaultPageSize;
+
+        var pagedItems = tournaments
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(t => new TournamentResultDto
+            {
+                Id = t.Id,
+                Name = t.Name,
+                Gender = t.Gender,
+                CreatedAt = t.CreatedAt,
+                Winner = t.Winner?.GetFullName() ?? string.Empty
+            })
+            .ToList();
+
+        return new PagedResultDto<TournamentResultDto>
+        {
+            TotalCount = totalCount,
+            Items = pagedItems
+        };
     }
+
 }

--- a/src/Challengers.Application/Features/Tournaments/Queries/GetTournamentsByFilter/GetTournamentsByFilterQuery.cs
+++ b/src/Challengers.Application/Features/Tournaments/Queries/GetTournamentsByFilter/GetTournamentsByFilterQuery.cs
@@ -3,4 +3,4 @@ using MediatR;
 
 namespace Challengers.Application.Features.Tournaments.Queries.GetTournamentsByFilter;
 
-public record GetTournamentsByFilterQuery(GetTournamentsQueryDto Dto) : IRequest<List<TournamentResultDto>>;
+public record GetTournamentsByFilterQuery(GetTournamentsQueryDto Dto) : IRequest<PagedResultDto<TournamentResultDto>>;

--- a/src/Challengers.Application/Interfaces/Persistence/IPlayerRepository.cs
+++ b/src/Challengers.Application/Interfaces/Persistence/IPlayerRepository.cs
@@ -8,6 +8,6 @@ public interface IPlayerRepository : IRepository<Player>
 {
     Task<List<Player>> GetPagedAsync(int page, int pageSize, CancellationToken cancellationToken);
     Task<int> CountAsync(CancellationToken cancellationToken);
-    Task<PagedResultDto<Player>> GetFilteredAsync(GetPlayersQueryDto dto, CancellationToken cancellationToken);
+    Task<List<Player>> GetFilteredAsync(GetPlayersQueryDto dto, CancellationToken cancellationToken);
     Task ReplaceAsync(Player player, CancellationToken cancellationToken);
 }

--- a/src/Challengers.Domain/Constants/PlayerConstants.cs
+++ b/src/Challengers.Domain/Constants/PlayerConstants.cs
@@ -7,17 +7,13 @@ public static class PlayerConstants
     public const int MinStat = 0;
     public const int MaxStat = 100;
 
-    public const int MinLuck = 0;
-    public const int MaxLuck = 10;
+    public const double MaleSkillWeight = 0.4;
+    public const double MaleStrengthWeight = 0.3;
+    public const double MaleSpeedWeight = 0.1;
 
-    public const double MaleSkillWeight = 0.5;
-    public const double MaleStrengthWeight = 0.25;
-    public const double MaleSpeedWeight = 0.2;
-
-    public const double FemaleSkillWeight = 0.6;
+    public const double FemaleSkillWeight = 0.3;
     public const double FemaleReactionTimeWeight = 0.3;
-    public const double LuckWeight = 1.0;
-    public const int LuckRangeAdjustment = 1;
+    public const double LuckWeight = 100;
 
     public const int DefaultPage = 1;
     public const int DefaultPageSize = 20;

--- a/src/Challengers.Domain/Entities/FemalePlayer.cs
+++ b/src/Challengers.Domain/Entities/FemalePlayer.cs
@@ -1,4 +1,5 @@
 ﻿using Challengers.Domain.Enums;
+using System.Globalization;
 
 namespace Challengers.Domain.Entities;
 
@@ -17,20 +18,20 @@ public class FemalePlayer : Player
         ReactionTime = reactionTime;
     }
 
-    protected override double CalculateScoreWithLuck(int luck)
+    protected override double CalculateScoreWithLuck(double luck)
     {
         return Skill * FemaleSkillWeight +
                ReactionTime * FemaleReactionTimeWeight +
                luck * LuckWeight;
     }
 
-    public override string ExplainScore(double score, int luck)
+    public override string ExplainScore(double score, double luck)
     {
         return FormatMessage(
             FemaleScoreExplanation,
             Skill, FemaleSkillWeight,
             ReactionTime, FemaleReactionTimeWeight,
-            luck, LuckWeight,
+            luck.ToString(CultureInfo.InvariantCulture), LuckWeight,
             score
         );
     }

--- a/src/Challengers.Domain/Entities/MalePlayer.cs
+++ b/src/Challengers.Domain/Entities/MalePlayer.cs
@@ -1,4 +1,5 @@
 ﻿using Challengers.Domain.Enums;
+using System.Globalization;
 
 namespace Challengers.Domain.Entities;
 
@@ -24,7 +25,7 @@ public class MalePlayer : Player
         Speed = speed;
     }
 
-    protected override double CalculateScoreWithLuck(int luck)
+    protected override double CalculateScoreWithLuck(double luck)
     {
         return Skill * MaleSkillWeight +
                Strength * MaleStrengthWeight +
@@ -32,14 +33,14 @@ public class MalePlayer : Player
                luck * LuckWeight;
     }
 
-    public override string ExplainScore(double score, int luck)
+    public override string ExplainScore(double score, double luck)
     {
         return FormatMessage(
             MaleScoreExplanation,
             Skill, MaleSkillWeight,
             Strength, MaleStrengthWeight,
             Speed, MaleSpeedWeight,
-            luck, LuckWeight,
+            luck.ToString(CultureInfo.InvariantCulture), LuckWeight,
             score
         );
     }

--- a/src/Challengers.Domain/Entities/Match.cs
+++ b/src/Challengers.Domain/Entities/Match.cs
@@ -1,4 +1,5 @@
 ﻿using Challengers.Domain.Common;
+using Challengers.Domain.Services;
 
 namespace Challengers.Domain.Entities;
 
@@ -17,19 +18,21 @@ public class Match : Entity<Guid>
     public Player? Winner { get; private set; }
 
     private bool _isSimulated;
-
+    private readonly IRandomGenerator _random = default!;
     private Match() { }
 
-    public Match(Player player1, Player player2)
+    public Match(Player player1, Player player2, IRandomGenerator? random = null)
     {
-        Player1 = player1 ?? throw new ArgumentException(MatchPlayersRequired);
-        Player2 = player2 ?? throw new ArgumentException(MatchPlayersRequired);
+        Player1 = player1 ?? throw new ArgumentException(GetMessage(MatchPlayersRequired));
+        Player2 = player2 ?? throw new ArgumentException(GetMessage(MatchPlayersRequired));
 
         Player1Id = player1.Id;
         Player2Id = player2.Id;
 
         if (player1.Id == player2.Id)
-            throw new ArgumentException(MatchSamePlayer);
+            throw new ArgumentException(GetMessage(MatchSamePlayer));
+
+        _random = random ?? new DefaultRandomGenerator();
     }
 
     public void SetTournament(Tournament tournament)
@@ -38,15 +41,13 @@ public class Match : Entity<Guid>
         TournamentId = tournament.Id;
     }
 
-    public void Simulate(Random? rng = null)
+    public void Simulate()
     {
         if (_isSimulated)
-            throw new InvalidOperationException(MatchAlreadySimulated);
+            throw new InvalidOperationException(GetMessage(MatchAlreadySimulated));
 
-        rng ??= new Random();
-
-        var luck1 = Player.GenerateLuck(rng);
-        var luck2 = Player.GenerateLuck(rng);
+        var luck1 = Player.GenerateLuck(_random);
+        var luck2 = Player.GenerateLuck(_random);
 
         var score1 = Player1.GetMatchScore(luck1);
         var score2 = Player2.GetMatchScore(luck2);

--- a/src/Challengers.Domain/Entities/Player.cs
+++ b/src/Challengers.Domain/Entities/Player.cs
@@ -1,5 +1,6 @@
 using Challengers.Domain.Common;
 using Challengers.Domain.Enums;
+using Challengers.Domain.Services;
 
 namespace Challengers.Domain.Entities;
 
@@ -28,27 +29,20 @@ public abstract class Player : Entity<Guid>
         Gender = gender;
     }
 
-    public static int GenerateLuck(Random? rng)
+    public static double GenerateLuck(IRandomGenerator rng)
     {
-        rng ??= new Random();
-        return rng.Next(MinLuck, MaxLuck + LuckRangeAdjustment);
+        return rng.NextDouble();
     }
 
-    public double GetMatchScore(int luck)
+    public double GetMatchScore(double luck)
     {
         return CalculateScoreWithLuck(luck);
     }
 
-    protected abstract double CalculateScoreWithLuck(int luck);
-    public abstract string ExplainScore(double score, int luck);
+    protected abstract double CalculateScoreWithLuck(double luck);
+    public abstract string ExplainScore(double score, double luck);
     public void SetName(string name) => Name = name;
     public void SetSurname(string surname) => Surname = surname;
     public void SetSkill(int skill) => Skill = skill;
     public string GetFullName() => $"{Name} {Surname}";
-    public void ForceSetId(Guid id)
-    {
-        typeof(Entity<Guid>)
-            .GetProperty(nameof(Id))!
-            .SetValue(this, id);
-    }
 }

--- a/src/Challengers.Domain/Entities/Tournament.cs
+++ b/src/Challengers.Domain/Entities/Tournament.cs
@@ -1,5 +1,6 @@
 ﻿using Challengers.Domain.Common;
 using Challengers.Domain.Enums;
+using Challengers.Domain.Services;
 using Challengers.Shared.Helpers;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -39,7 +40,7 @@ public class Tournament : Entity<Guid>
         Players.AddRange(players);
     }
 
-    public void Simulate(Random? rng = null)
+    public void Simulate(IRandomGenerator? rng = null)
     {
         if (_isCompleted)
             throw new InvalidOperationException(GetMessage(TournamentAlreadyCompleted));
@@ -47,14 +48,14 @@ public class Tournament : Entity<Guid>
         if (Players.Count < MinPlayers || !IsPowerOfTwo(Players.Count))
             throw new ArgumentException(GetMessage(TournamentInvalidPlayerCount));
 
-        rng ??= new Random();
+        rng ??= new DefaultRandomGenerator();
         var queue = new Queue<Player>(Players);
 
         while (queue.Count > 1)
         {
-            var match = new Match(queue.Dequeue(), queue.Dequeue());
+            var match = new Match(queue.Dequeue(), queue.Dequeue(), rng);
             match.SetTournament(this);
-            match.Simulate(rng);
+            match.Simulate();
             Matches.Add(match);
             queue.Enqueue(match.Winner!);
         }

--- a/src/Challengers.Domain/Services/DefaultRandomGenerator.cs
+++ b/src/Challengers.Domain/Services/DefaultRandomGenerator.cs
@@ -1,0 +1,8 @@
+﻿namespace Challengers.Domain.Services;
+
+public class DefaultRandomGenerator : IRandomGenerator
+{
+    private readonly Random _random = new();
+
+    public double NextDouble() => _random.NextDouble();
+}

--- a/src/Challengers.Domain/Services/IRandomGenerator.cs
+++ b/src/Challengers.Domain/Services/IRandomGenerator.cs
@@ -1,0 +1,6 @@
+﻿namespace Challengers.Domain.Services;
+
+public interface IRandomGenerator
+{
+    double NextDouble();
+}

--- a/src/Challengers.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Challengers.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Challengers.Application.Interfaces.Persistence;
+using Challengers.Infrastructure.Auth;
 using Challengers.Infrastructure.Persistence.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -11,6 +12,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IPlayerRepository, PlayerRepository>();
         services.AddScoped<ITournamentRepository, TournamentRepository>();
         services.AddScoped<IMatchRepository, MatchRepository>();
+        services.AddScoped<JwtTokenGenerator>();
 
         return services;
     }

--- a/src/Challengers.Infrastructure/Persistence/Repositories/PlayerRepository.cs
+++ b/src/Challengers.Infrastructure/Persistence/Repositories/PlayerRepository.cs
@@ -22,7 +22,7 @@ public class PlayerRepository(ChallengersDbContext context)
         return await _context.Players.CountAsync(cancellationToken);
     }
 
-    public async Task<PagedResultDto<Player>> GetFilteredAsync(GetPlayersQueryDto dto, CancellationToken cancellationToken)
+    public async Task<List<Player>> GetFilteredAsync(GetPlayersQueryDto dto, CancellationToken cancellationToken)
     {
         var query = _context.Players.AsNoTracking().AsQueryable();
 
@@ -41,19 +41,9 @@ public class PlayerRepository(ChallengersDbContext context)
             query = query.Where(p => p.Surname.Contains(dto.Surname));
         }
 
-        var total = await query.CountAsync(cancellationToken);
-        var players = await query
-            .Skip(((dto.Page ?? 1) - 1) * (dto.PageSize ?? 20))
-            .Take(dto.PageSize ?? 20)
-            .ToListAsync(cancellationToken);
+        var players = await query.ToListAsync(cancellationToken);
 
-        return new PagedResultDto<Player>
-        {
-            Items = players,
-            TotalCount = total,
-            Page = dto.Page ?? 1,
-            PageSize = dto.PageSize ?? 20
-        };
+        return players;
     }
     public async Task ReplaceAsync(Player player, CancellationToken cancellationToken)
     {

--- a/src/Challengers.Shared/Resources/Messages.Designer.cs
+++ b/src/Challengers.Shared/Resources/Messages.Designer.cs
@@ -412,7 +412,7 @@ namespace Challengers.Shared.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Tournament not found..
+        ///   Looks up a localized string similar to Tournament with ID {0} not found..
         /// </summary>
         internal static string TournamentNotFound {
             get {

--- a/src/Challengers.Shared/Resources/Messages.es.resx
+++ b/src/Challengers.Shared/Resources/Messages.es.resx
@@ -172,7 +172,7 @@
     <value>Error de formato en mensaje: {0}</value>
   </data>
   <data name="TournamentNotFound" xml:space="preserve">
-    <value>Torneo no encontrado.</value>
+    <value>Torneo con ID {0} no encontrado.</value>
   </data>
   <data name="PlayerIdNotFound" xml:space="preserve">
     <value>Jugador con ID {0} no encontrado.</value>
@@ -244,6 +244,6 @@
     <value>Los siguientes jugadores no coinciden con el género del torneo '{0}': {1}.</value>
   </data>
   <data name="TournamentGenderRequired" xml:space="preserve">
-    <value />
+    <value>Se requiere el género del torneo.</value>
   </data>
 </root>

--- a/src/Challengers.Shared/Resources/Messages.resx
+++ b/src/Challengers.Shared/Resources/Messages.resx
@@ -172,7 +172,7 @@
     <value> Format error in message: {0}</value>
   </data>
   <data name="TournamentNotFound" xml:space="preserve">
-    <value>Tournament not found.</value>
+    <value>Tournament with ID {0} not found.</value>
   </data>
   <data name="PlayerIdNotFound" xml:space="preserve">
     <value>Player with ID {0} not found.</value>

--- a/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Commands/CreatePlayer/CreatePlayerHandlerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Commands/CreatePlayer/CreatePlayerHandlerTests.cs
@@ -1,0 +1,104 @@
+﻿using Challengers.Application.DTOs;
+using Challengers.Application.Features.Players.Commands.CreatePlayer;
+using Challengers.Application.Interfaces.Persistence;
+using Challengers.Domain.Entities;
+using Challengers.Domain.Enums;
+using Challengers.UnitTests.TestHelpers;
+using FluentAssertions;
+using Moq;
+
+namespace Challengers.UnitTests.Challengers.Application.Features.Players.Commands.CreatePlayer
+{
+    public class CreatePlayerHandlerTests
+    {
+        [Fact]
+        public async Task Handle_ShouldCreateMalePlayerCorrectly()
+        {
+            // Arrange
+            var dto = new CreatePlayerRequestDto
+            {
+                Name = "Juan",
+                Surname = "Pérez",
+                Gender = Gender.Male,
+                Skill = 80,
+                Strength = 85,
+                Speed = 70
+            };
+
+            var repositoryMock = new Mock<IPlayerRepository>();
+            repositoryMock
+                .Setup(r => r.AddAsync(It.IsAny<MalePlayer>(), It.IsAny<CancellationToken>()))
+                .Callback<Player, CancellationToken>((p, _) => p.WithRandomId());
+
+            var handler = new CreatePlayerHandler(repositoryMock.Object);
+            var command = new CreatePlayerCommand(dto);
+
+            // Act
+            var id = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            repositoryMock.Verify(r => r.AddAsync(It.IsAny<MalePlayer>(), It.IsAny<CancellationToken>()), Times.Once);
+            repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+            id.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public async Task Handle_ShouldCreateFemalePlayerCorrectly()
+        {
+            // Arrange
+            var dto = new CreatePlayerRequestDto
+            {
+                Name = "Ana",
+                Surname = "Lopez",
+                Gender = Gender.Female,
+                Skill = 90,
+                ReactionTime = 85
+            };
+
+            var repositoryMock = new Mock<IPlayerRepository>();
+            repositoryMock
+                .Setup(r => r.AddAsync(It.IsAny<FemalePlayer>(), It.IsAny<CancellationToken>()))
+                .Callback<Player, CancellationToken>((p, _) => p.WithRandomId());
+
+            var handler = new CreatePlayerHandler(repositoryMock.Object);
+            var command = new CreatePlayerCommand(dto);
+
+            // Act
+            var id = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            repositoryMock.Verify(r => r.AddAsync(It.IsAny<FemalePlayer>(), It.IsAny<CancellationToken>()), Times.Once);
+            repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+            id.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public async Task Handle_ShouldThrow_WhenGenderIsInvalid()
+        {
+            // Arrange
+            var dto = new CreatePlayerRequestDto
+            {
+                Name = "Alex",
+                Surname = "Test",
+                Gender = (Gender)99,
+                Skill = 80
+            };
+
+            var repositoryMock = new Mock<IPlayerRepository>();
+            repositoryMock
+                .Setup(r => r.AddAsync(It.IsAny<MalePlayer>(), It.IsAny<CancellationToken>()))
+                .Callback<Player, CancellationToken>((p, _) => p.WithRandomId());
+
+            var handler = new CreatePlayerHandler(repositoryMock.Object);
+            var command = new CreatePlayerCommand(dto);
+
+            // Act
+            Func<Task> act = async () => await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentException>()
+                     .WithMessage("*Invalid*");
+        }
+
+    }
+}

--- a/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Commands/DeletePlayer/DeletePlayerHandlerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Commands/DeletePlayer/DeletePlayerHandlerTests.cs
@@ -1,0 +1,56 @@
+﻿using Challengers.Application.Features.Players.Commands.DeletePlayer;
+using Challengers.Application.Interfaces.Persistence;
+using Challengers.Domain.Entities;
+using Challengers.UnitTests.TestHelpers;
+using FluentAssertions;
+using Moq;
+
+namespace Challengers.UnitTests.Challengers.Application.Features.Players.Commands.DeletePlayer
+{
+    public class DeletePlayerHandlerTests
+    {
+        [Fact]
+        public async Task Handle_ShouldDeletePlayer_WhenExists()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+            var player = new MalePlayer("Juan", "Pérez", 80, 70, 60).WithId(id);
+
+            var repositoryMock = new Mock<IPlayerRepository>();
+            repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+                          .ReturnsAsync(player);
+
+            var handler = new DeletePlayerHandler(repositoryMock.Object);
+            var command = new DeletePlayerCommand(id);
+
+            // Act
+            await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            repositoryMock.Verify(r => r.Delete(player), Times.Once);
+            repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldThrow_WhenPlayerNotFound()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+
+            var repositoryMock = new Mock<IPlayerRepository>();
+            repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+                          .ReturnsAsync((Player?)null);
+
+            var handler = new DeletePlayerHandler(repositoryMock.Object);
+            var command = new DeletePlayerCommand(id);
+
+            // Act
+            Func<Task> act = async () => await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            await act.Should().ThrowAsync<KeyNotFoundException>()
+                     .WithMessage($"*{id}*");
+        }
+
+    }
+}

--- a/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Commands/UpdatePlayer/UpdatePlayerHandlerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Commands/UpdatePlayer/UpdatePlayerHandlerTests.cs
@@ -1,0 +1,151 @@
+﻿using Challengers.Application.DTOs;
+using Challengers.Application.Features.Players.Commands.UpdatePlayer;
+using Challengers.Application.Interfaces.Persistence;
+using Challengers.Domain.Entities;
+using Challengers.Domain.Enums;
+using Challengers.UnitTests.TestHelpers;
+using FluentAssertions;
+using Moq;
+
+namespace Challengers.UnitTests.Challengers.Application.Features.Players.Commands.UpdatePlayer
+{
+    public class UpdatePlayerHandlerTests
+    {
+        [Fact]
+        public async Task Handle_ShouldUpdateMalePlayer_WhenGenderIsUnchanged()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+            var existing = new MalePlayer("Juan", "Pérez", 80, 70, 60);
+            existing.WithId(id);
+
+            var dto = new UpdatePlayerRequestDto
+            {
+                Name = "Carlos",
+                Surname = "Lopez",
+                Skill = 90,
+                Strength = 85,
+                Speed = 75,
+                Gender = Gender.Male
+            };
+
+            var repositoryMock = new Mock<IPlayerRepository>();
+            repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+                          .ReturnsAsync(existing);
+
+            var handler = new UpdatePlayerHandler(repositoryMock.Object);
+            var command = new UpdatePlayerCommand(id, dto);
+
+            // Act
+            await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            existing.Name.Should().Be("Carlos");
+            existing.Surname.Should().Be("Lopez");
+            existing.Skill.Should().Be(90);
+            existing.Strength.Should().Be(85);
+            existing.Speed.Should().Be(75);
+
+            repositoryMock.Verify(r => r.Update(existing), Times.Once);
+            repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReplacePlayer_WhenGenderChanges()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+            var existing = new MalePlayer("Juan", "Pérez", 80, 70, 60);
+            existing.WithId(id);
+
+            var dto = new UpdatePlayerRequestDto
+            {
+                Name = "Ana",
+                Surname = "Lopez",
+                Skill = 85,
+                ReactionTime = 90,
+                Gender = Gender.Female
+            };
+
+            var repositoryMock = new Mock<IPlayerRepository>();
+            repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+                          .ReturnsAsync(existing);
+
+            var handler = new UpdatePlayerHandler(repositoryMock.Object);
+            var command = new UpdatePlayerCommand(id, dto);
+
+            // Act
+            await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            repositoryMock.Verify(r => r.ReplaceAsync(It.Is<FemalePlayer>(
+                p => p.Name == "Ana" && p.Surname == "Lopez" && p.Skill == 85 && p.ReactionTime == 90
+                     && p.Id == id
+            ), It.IsAny<CancellationToken>()), Times.Once);
+
+            repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldThrow_WhenPlayerNotFound()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+            var dto = new UpdatePlayerRequestDto
+            {
+                Name = "Juan",
+                Surname = "Pérez",
+                Skill = 80,
+                Gender = Gender.Male,
+                Strength = 70,
+                Speed = 60
+            };
+
+            var repositoryMock = new Mock<IPlayerRepository>();
+            repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+                          .ReturnsAsync((Player?)null);
+
+            var handler = new UpdatePlayerHandler(repositoryMock.Object);
+            var command = new UpdatePlayerCommand(id, dto);
+
+            // Act
+            Func<Task> act = async () => await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            await act.Should().ThrowAsync<KeyNotFoundException>()
+                     .WithMessage($"*{id}*");
+        }
+
+        [Fact]
+        public async Task Handle_ShouldThrow_WhenGenderIsInvalid()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+            var existing = new MalePlayer("Juan", "Pérez", 80, 70, 60);
+            existing.WithId(id);
+
+            var dto = new UpdatePlayerRequestDto
+            {
+                Name = "Test",
+                Surname = "Test",
+                Skill = 70,
+                Gender = (Gender)99
+            };
+
+            var repositoryMock = new Mock<IPlayerRepository>();
+            repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+                          .ReturnsAsync(existing);
+
+            var handler = new UpdatePlayerHandler(repositoryMock.Object);
+            var command = new UpdatePlayerCommand(id, dto);
+
+            // Act
+            Func<Task> act = async () => await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentException>()
+                     .WithMessage("*Invalid*");
+        }
+
+    }
+}

--- a/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Queries/GetPlayerById/GetPlayerByIdHandlerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Queries/GetPlayerById/GetPlayerByIdHandlerTests.cs
@@ -1,0 +1,57 @@
+﻿using Challengers.Application.Features.Players.Queries.GetPlayerById;
+using Challengers.Application.Interfaces.Persistence;
+using Challengers.Domain.Entities;
+using Challengers.UnitTests.TestHelpers;
+using FluentAssertions;
+using Moq;
+
+namespace Challengers.UnitTests.Challengers.Application.Features.Players.Queries.GetPlayerById;
+
+public class GetPlayerByIdHandlerTests
+{
+    [Fact]
+    public async Task Handle_ShouldReturnPlayerDto_WhenFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var player = new MalePlayer("Juan", "Pérez", 80, 70, 60).WithId(id);
+
+        var repositoryMock = new Mock<IPlayerRepository>();
+        repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+                      .ReturnsAsync(player);
+
+        var handler = new GetPlayerByIdHandler(repositoryMock.Object);
+        var query = new GetPlayerByIdQuery(id);
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Id.Should().Be(id);
+        result.Name.Should().Be("Juan");
+        result.Strength.Should().Be(70);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldThrow_WhenPlayerNotFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        var repositoryMock = new Mock<IPlayerRepository>();
+        repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+                      .ReturnsAsync((Player?)null);
+
+        var handler = new GetPlayerByIdHandler(repositoryMock.Object);
+        var query = new GetPlayerByIdQuery(id);
+
+        // Act
+        Func<Task> act = async () => await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<KeyNotFoundException>()
+                 .WithMessage($"*{id}*");
+    }
+
+}

--- a/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Queries/GetPlayers/GetPlayersQueryHandlerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Queries/GetPlayers/GetPlayersQueryHandlerTests.cs
@@ -1,0 +1,96 @@
+﻿using Challengers.Application.DTOs;
+using Challengers.Application.Features.Players.Queries.GetPlayers;
+using Challengers.Application.Interfaces.Persistence;
+using Challengers.Domain.Entities;
+using Challengers.Domain.Enums;
+using Challengers.UnitTests.TestHelpers;
+using FluentAssertions;
+using Moq;
+
+namespace Challengers.UnitTests.Challengers.Application.Features.Players.Queries.GetPlayers;
+
+public class GetPlayersQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_ShouldReturnFilteredPlayers_ByGender()
+    {
+        var players = new List<Player>
+        {
+            new MalePlayer("Juan", "Pérez", 80, 70, 60).WithRandomId(),
+            new FemalePlayer("Ana", "Gomez", 85, 75).WithRandomId(),
+            new FemalePlayer("Laura", "Lopez", 90, 80).WithRandomId()
+        };
+
+        var femalePlayers = players.Where(p => p.Gender == Gender.Female);
+        var pagedResult = new PagedResultDto<Player>
+        {
+            Items = [.. femalePlayers],
+            TotalCount = 2
+        };
+
+        var repositoryMock = new Mock<IPlayerRepository>();
+        repositoryMock.Setup(r => r.GetFilteredAsync(It.IsAny<GetPlayersQueryDto>(), It.IsAny<CancellationToken>()))
+                      .ReturnsAsync([..femalePlayers]);
+
+        var handler = new GetPlayersQueryHandler(repositoryMock.Object);
+        var query = new GetPlayersQuery(new GetPlayersQueryDto { Gender = Gender.Female });
+
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        result.Items.Should().HaveCount(2);
+        result.Items.All(p => p.Gender == Gender.Female).Should().BeTrue();
+    }
+
+
+    [Fact]
+    public async Task Handle_ShouldReturnEmptyList_WhenNoPlayersMatch()
+    {
+        var pagedResult = new PagedResultDto<Player>
+        {
+            Items = [],
+            TotalCount = 0
+        };
+
+        var repositoryMock = new Mock<IPlayerRepository>();
+        repositoryMock.Setup(r => r.GetFilteredAsync(It.IsAny<GetPlayersQueryDto>(), It.IsAny<CancellationToken>()))
+                      .ReturnsAsync([]);
+
+        var handler = new GetPlayersQueryHandler(repositoryMock.Object);
+        var query = new GetPlayersQuery(new GetPlayersQueryDto { Name = "NoExiste" });
+
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        result.Items.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
+    }
+
+
+    [Fact]
+    public async Task Handle_ShouldMapPlayerCorrectlyToDto()
+    {
+        var player = new MalePlayer("Carlos", "Diaz", 75, 70, 65).WithRandomId();
+
+        var pagedResult = new PagedResultDto<Player>
+        {
+            Items = [player],
+            TotalCount = 1
+        };
+
+        var repositoryMock = new Mock<IPlayerRepository>();
+        repositoryMock.Setup(r => r.GetFilteredAsync(It.IsAny<GetPlayersQueryDto>(), It.IsAny<CancellationToken>()))
+                      .ReturnsAsync([player]);
+
+        var handler = new GetPlayersQueryHandler(repositoryMock.Object);
+        var query = new GetPlayersQuery(new GetPlayersQueryDto());
+
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        result.Items.Should().ContainSingle(p =>
+            p.Name == "Carlos" &&
+            p.Surname == "Diaz" &&
+            p.Skill == 75 &&
+            p.Strength == 70 &&
+            p.Speed == 65
+        );
+    }
+}

--- a/tests/Challengers.UnitTests/Challengers.Application/Features/Tournaments/Commands/CreateTournament/CreateTournamentHandlerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Features/Tournaments/Commands/CreateTournament/CreateTournamentHandlerTests.cs
@@ -1,0 +1,253 @@
+﻿using Challengers.Application.DTOs;
+using Challengers.Application.Features.Tournaments.Commands.CreateTournament;
+using Challengers.Application.Interfaces.Persistence;
+using Challengers.Domain.Entities;
+using Challengers.Domain.Enums;
+using Challengers.UnitTests.TestHelpers;
+using FluentAssertions;
+using Moq;
+
+namespace Challengers.UnitTests.Challengers.Application.Features.Tournaments.Commands.CreateTournament;
+
+public class CreateTournamentHandlerTests
+{
+    [Fact]
+    public async Task Handle_ShouldCreateTournamentWithNewPlayers_WhenSavePlayersIsTrue()
+    {
+        // Arrange
+        var dto = new CreateTournamentRequestDto
+        {
+            Name = "Open de Córdoba",
+            Gender = Gender.Female,
+            SavePlayers = true,
+            Players =
+            [
+                new() { Name = "Ana", Surname = "López", Skill = 85, ReactionTime = 80, Gender = Gender.Female },
+                new() { Name = "Laura", Surname = "Pérez", Skill = 88, ReactionTime = 82, Gender = Gender.Female }
+            ]
+        };
+
+        var tournamentRepo = new Mock<ITournamentRepository>();
+        var playerRepo = new Mock<IPlayerRepository>();
+
+        tournamentRepo.Setup(r => r.ExistsByNameAsync(dto.Name, It.IsAny<CancellationToken>()))
+                      .ReturnsAsync(false);
+        tournamentRepo
+            .Setup(r => r.AddAsync(It.IsAny<Tournament>(), It.IsAny<CancellationToken>()))
+            .Callback<Tournament, CancellationToken>((t, _) =>
+            {
+                typeof(Tournament).GetProperty(nameof(Tournament.Id))!
+                    .SetValue(t, Guid.NewGuid());
+            })
+            .Returns(Task.CompletedTask);
+
+        playerRepo
+            .Setup(r => r.AddAsync(It.IsAny<Player>(), It.IsAny<CancellationToken>()));
+
+        var handler = new CreateTournamentHandler(tournamentRepo.Object, playerRepo.Object);
+        var command = new CreateTournamentCommand(dto);
+
+        // Act
+        var response = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        tournamentRepo.Verify(r => r.AddAsync(It.Is<Tournament>(t => t.Name == dto.Name), default), Times.Once);
+        playerRepo.Verify(r => r.AddAsync(It.IsAny<Player>(), default), Times.Exactly(2));
+        playerRepo.Verify(r => r.SaveChangesAsync(default), Times.Once);
+        tournamentRepo.Verify(r => r.SaveChangesAsync(default), Times.Once);
+        response.TournamentId.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreateTournamentUsingExistingPlayers()
+    {
+        // Arrange
+        var existingPlayerIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
+
+        var dto = new CreateTournamentRequestDto
+        {
+            Name = "Challengers Cup",
+            Gender = Gender.Male,
+            SavePlayers = false,
+            Players = [.. existingPlayerIds.Select(id => new PlayerDto { Id = id, Gender = Gender.Male })]
+        };
+
+        var tournamentRepo = new Mock<ITournamentRepository>();
+        var playerRepo = new Mock<IPlayerRepository>();
+
+        tournamentRepo.Setup(r => r.ExistsByNameAsync(dto.Name, default)).ReturnsAsync(false);
+
+        foreach (var id in existingPlayerIds)
+        {
+            var player = new MalePlayer("Juan", "X", 80, 80, 80).WithId(id);
+            playerRepo.Setup(r => r.GetByIdAsync(id, default)).ReturnsAsync(player);
+        }
+
+        tournamentRepo
+            .Setup(r => r.AddAsync(It.IsAny<Tournament>(), default))
+            .Callback<Tournament, CancellationToken>((t, _) =>
+                typeof(Tournament).GetProperty(nameof(Tournament.Id))!.SetValue(t, Guid.NewGuid()))
+            .Returns(Task.CompletedTask);
+
+        var handler = new CreateTournamentHandler(tournamentRepo.Object, playerRepo.Object);
+        var command = new CreateTournamentCommand(dto);
+
+        // Act
+        var response = await handler.Handle(command, default);
+
+        // Assert
+        playerRepo.Verify(r => r.GetByIdAsync(It.IsAny<Guid>(), default), Times.Exactly(2));
+        playerRepo.Verify(r => r.AddAsync(It.IsAny<Player>(), default), Times.Never);
+        tournamentRepo.Verify(r => r.AddAsync(It.IsAny<Tournament>(), default), Times.Once);
+        response.TournamentId.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreateTournamentWithMixedPlayers_FromSinglePlayersList()
+    {
+        // Arrange
+        var existingId = Guid.NewGuid();
+
+        var dto = new CreateTournamentRequestDto
+        {
+            Name = "Mix Open",
+            Gender = Gender.Female,
+            SavePlayers = true,
+            Players =
+        [
+            new() { Id = existingId },
+            new() { Name = "Caro", Surname = "Y", Skill = 85, ReactionTime = 75, Gender = Gender.Female }
+        ]
+        };
+
+        var tournamentRepo = new Mock<ITournamentRepository>();
+        var playerRepo = new Mock<IPlayerRepository>();
+
+        tournamentRepo.Setup(r => r.ExistsByNameAsync(dto.Name, default)).ReturnsAsync(false);
+
+        playerRepo.Setup(r => r.GetByIdAsync(existingId, default))
+                  .ReturnsAsync(new FemalePlayer("Ana", "X", 80, 80).WithId(existingId));
+
+        playerRepo.Setup(r => r.AddAsync(It.IsAny<Player>(), It.IsAny<CancellationToken>()))
+                  .Callback<Player, CancellationToken>((p, _) => p.WithRandomId())
+                  .Returns(Task.CompletedTask);
+
+        tournamentRepo.Setup(r => r.AddAsync(It.IsAny<Tournament>(), default))
+                      .Callback<Tournament, CancellationToken>((t, _) =>
+                          typeof(Tournament).GetProperty(nameof(Tournament.Id))!.SetValue(t, Guid.NewGuid()))
+                      .Returns(Task.CompletedTask);
+
+        var handler = new CreateTournamentHandler(tournamentRepo.Object, playerRepo.Object);
+        var command = new CreateTournamentCommand(dto);
+
+        // Act
+        var result = await handler.Handle(command, default);
+
+        // Assert
+        playerRepo.Verify(r => r.GetByIdAsync(existingId, default), Times.Once);
+        playerRepo.Verify(r => r.AddAsync(It.IsAny<Player>(), default), Times.Once);
+        playerRepo.Verify(r => r.SaveChangesAsync(default), Times.Once);
+        tournamentRepo.Verify(r => r.AddAsync(It.IsAny<Tournament>(), default), Times.Once);
+        tournamentRepo.Verify(r => r.SaveChangesAsync(default), Times.Once);
+        result.TournamentId.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldThrow_WhenPlayersHaveMixedGenders()
+    {
+        // Arrange
+        var maleId = Guid.NewGuid();
+        var femaleId = Guid.NewGuid();
+        var dto = new CreateTournamentRequestDto
+        {
+            Name = "Torneo Mixto",
+            Gender = Gender.Male,
+            SavePlayers = false,
+            Players =
+            [
+                new() { Id = maleId },
+                new() { Id = femaleId }
+            ]
+        };
+
+        var playerRepo = new Mock<IPlayerRepository>();
+        var tournamentRepo = new Mock<ITournamentRepository>();
+
+        playerRepo.Setup(r => r.GetByIdAsync(maleId, default))
+          .ReturnsAsync(new MalePlayer("Juan", "X", 80, 80, 80).WithId(maleId));
+
+        playerRepo.Setup(r => r.GetByIdAsync(femaleId, default))
+                  .ReturnsAsync(new FemalePlayer("Ana", "Y", 85, 75).WithId(femaleId));
+
+        var handler = new CreateTournamentHandler(tournamentRepo.Object, playerRepo.Object);
+        var command = new CreateTournamentCommand(dto);
+
+        // Act
+        Func<Task> act = async () => await handler.Handle(command, default);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+                 .WithMessage("*gender*");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldThrow_WhenReferencedPlayerNotFound()
+    {
+        // Arrange
+        var missingId = Guid.NewGuid();
+
+        var dto = new CreateTournamentRequestDto
+        {
+            Name = "Con Fantasma",
+            Gender = Gender.Female,
+            SavePlayers = false,
+            Players = [new() { Id = missingId }]
+        };
+
+        var playerRepo = new Mock<IPlayerRepository>();
+        var tournamentRepo = new Mock<ITournamentRepository>();
+
+        playerRepo.Setup(r => r.GetByIdAsync(missingId, default))
+                  .ReturnsAsync((Player?)null);
+
+        var handler = new CreateTournamentHandler(tournamentRepo.Object, playerRepo.Object);
+        var command = new CreateTournamentCommand(dto);
+
+        // Act
+        Func<Task> act = async () => await handler.Handle(command, default);
+
+        // Assert
+        await act.Should().ThrowAsync<KeyNotFoundException>()
+                 .WithMessage($"*{missingId}*");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldThrow_WhenTournamentNameAlreadyExists()
+    {
+        // Arrange
+        var dto = new CreateTournamentRequestDto
+        {
+            Name = "Córdoba Open",
+            Gender = Gender.Female,
+            SavePlayers = false,
+            Players = [new() { Id = Guid.NewGuid() }]
+        };
+
+        var playerRepo = new Mock<IPlayerRepository>();
+        var tournamentRepo = new Mock<ITournamentRepository>();
+
+        tournamentRepo.Setup(r => r.ExistsByNameAsync(dto.Name, default))
+                      .ReturnsAsync(true);
+
+        var handler = new CreateTournamentHandler(tournamentRepo.Object, playerRepo.Object);
+        var command = new CreateTournamentCommand(dto);
+
+        // Act
+        Func<Task> act = async () => await handler.Handle(command, default);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+                 .WithMessage("*already exists*");
+    }
+
+}

--- a/tests/Challengers.UnitTests/Challengers.Application/Features/Tournaments/Commands/SimulateTournament/SimulateTournamentHandlerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Features/Tournaments/Commands/SimulateTournament/SimulateTournamentHandlerTests.cs
@@ -1,0 +1,88 @@
+﻿using Challengers.Application.Features.Tournaments.Commands.SimulateTournament;
+using Challengers.Application.Interfaces.Persistence;
+using Challengers.Domain.Entities;
+using Challengers.Domain.Enums;
+using Challengers.UnitTests.TestHelpers;
+using FluentAssertions;
+using Moq;
+using System.Diagnostics;
+
+namespace Challengers.UnitTests.Challengers.Application.Features.Tournaments.Commands.SimulateTournament;
+
+public class SimulateTournamentHandlerTests
+{
+    [Fact]
+    public async Task Handle_ShouldSimulateTournament_WhenValid()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var players = new List<Player>
+        {
+            new FemalePlayer("Ana", "X", 80, 80).WithRandomId(),
+            new FemalePlayer("Laura", "Y", 85, 75).WithRandomId()
+        };
+        var tournament = new Tournament("Simulable", Gender.Female, players).WithId(id);
+        Debug.WriteLine($"tournament id {tournament.Id}, id {id}");
+        var repo = new Mock<ITournamentRepository>();
+        repo.Setup(r => r.GetWithDetailsAsync(id, default)).ReturnsAsync(tournament);
+
+        var handler = new SimulateTournamentHandler(repo.Object);
+        var command = new SimulateTournamentCommand(id);
+
+        // Act
+        await handler.Handle(command, default);
+
+        // Assert
+        tournament.IsCompleted.Should().BeTrue();
+        tournament.Winner.Should().NotBeNull();
+        tournament.Matches.Should().NotBeEmpty();
+        repo.Verify(r => r.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldThrow_WhenTournamentNotFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var repo = new Mock<ITournamentRepository>();
+        repo.Setup(r => r.GetWithDetailsAsync(id, default)).ReturnsAsync((Tournament?)null);
+
+        var handler = new SimulateTournamentHandler(repo.Object);
+        var command = new SimulateTournamentCommand(id);
+
+        // Act
+        Func<Task> act = async () => await handler.Handle(command, default);
+
+        // Assert
+        await act.Should().ThrowAsync<KeyNotFoundException>()
+                 .WithMessage($"*{id}*");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldThrow_WhenTournamentAlreadySimulated()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var players = new List<Player>
+        {
+            new FemalePlayer("Ana", "X", 80, 80).WithRandomId(),
+            new FemalePlayer("Laura", "Y", 85, 75).WithRandomId()
+        };
+        var tournament = new Tournament("Simulado", Gender.Female, players).WithId(id);
+        tournament.Simulate();
+
+        var repo = new Mock<ITournamentRepository>();
+        repo.Setup(r => r.GetWithDetailsAsync(id, default)).ReturnsAsync(tournament);
+
+        var handler = new SimulateTournamentHandler(repo.Object);
+        var command = new SimulateTournamentCommand(id);
+
+        // Act
+        Func<Task> act = async () => await handler.Handle(command, default);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+                 .WithMessage("*already*");
+    }
+
+}

--- a/tests/Challengers.UnitTests/Challengers.Application/Features/Tournaments/Queries/GetTournamentResult/GetTournamentResultHandlerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Features/Tournaments/Queries/GetTournamentResult/GetTournamentResultHandlerTests.cs
@@ -1,0 +1,62 @@
+﻿using Challengers.Application.Features.Tournaments.Queries.GetTournamentResult;
+using Challengers.Application.Interfaces.Persistence;
+using Challengers.Domain.Entities;
+using Challengers.Domain.Enums;
+using Challengers.UnitTests.TestHelpers;
+using FluentAssertions;
+using Moq;
+
+namespace Challengers.UnitTests.Challengers.Application.Features.Tournaments.Queries.GetTournamentResult;
+
+public class GetTournamentResultHandlerTests
+{
+    [Fact]
+    public async Task Handle_ShouldReturnTournamentResult_WhenTournamentExists()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var player1 = new FemalePlayer("Ana", "López", 85, 80).WithRandomId();
+        var player2 = new FemalePlayer("Laura", "Pérez", 88, 82).WithRandomId();
+        var tournament = new Tournament("Finalizado", Gender.Female, [player1, player2]).WithId(id);
+
+        tournament.Simulate();
+
+        var repo = new Mock<ITournamentRepository>();
+        repo.Setup(r => r.GetWithDetailsAsync(id, default)).ReturnsAsync(tournament);
+
+        var handler = new GetTournamentResultHandler(repo.Object);
+        var query = new GetTournamentResultQuery(id);
+
+        // Act
+        var result = await handler.Handle(query, default);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Id.Should().Be(id);
+        result.Name.Should().Be("Finalizado");
+        result.Gender.Should().Be(Gender.Female);
+        result.Winner.Should().Be(tournament.Winner!.GetFullName());
+    }
+
+    [Fact]
+    public async Task Handle_ShouldThrow_WhenTournamentNotFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        var repo = new Mock<ITournamentRepository>();
+        repo.Setup(r => r.GetWithDetailsAsync(id, default))
+            .ReturnsAsync((Tournament?)null);
+
+        var handler = new GetTournamentResultHandler(repo.Object);
+        var query = new GetTournamentResultQuery(id);
+
+        // Act
+        Func<Task> act = async () => await handler.Handle(query, default);
+
+        // Assert
+        await act.Should().ThrowAsync<KeyNotFoundException>()
+                 .WithMessage($"*{id}*");
+    }
+
+}

--- a/tests/Challengers.UnitTests/Challengers.Application/Features/Tournaments/Queries/GetTournamentsByFilter/GetTournamentsByFilterHandlerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Features/Tournaments/Queries/GetTournamentsByFilter/GetTournamentsByFilterHandlerTests.cs
@@ -1,0 +1,71 @@
+﻿using Challengers.Application.DTOs;
+using Challengers.Application.Features.Tournaments.Queries.GetTournamentsByFilter;
+using Challengers.Application.Interfaces.Persistence;
+using Challengers.Domain.Entities;
+using Challengers.Domain.Enums;
+using Challengers.UnitTests.TestHelpers;
+using FluentAssertions;
+using Moq;
+
+namespace Challengers.UnitTests.Challengers.Application.Features.Tournaments.Queries.GetTournamentsByFilter;
+
+public class GetTournamentsByFilterHandlerTests
+{
+    [Fact]
+    public async Task Handle_ShouldReturnPagedTournaments_WhenMatchesExist()
+    {
+        // Arrange
+        var tournaments = new List<Tournament>
+        {
+            new Tournament("Torneo 1", Gender.Male, TestHelper.FakePlayers(Male: true, count: 2)).SimulateAndReturn(),
+            new Tournament("Torneo 2", Gender.Male, TestHelper.FakePlayers(Male: true, count: 2)).SimulateAndReturn()
+        };
+        tournaments.ForEach(t => t.WithRandomId());
+
+        var paged = new PagedResultDto<Tournament>
+        {
+            Items = tournaments,
+            TotalCount = 2
+        };
+
+        var repo = new Mock<ITournamentRepository>();
+        repo.Setup(r => r.GetFilteredAsync(It.IsAny<GetTournamentsQueryDto>(), default)).ReturnsAsync(tournaments);
+
+        var handler = new GetTournamentsByFilterHandler(repo.Object);
+        var query = new GetTournamentsByFilterQuery(new GetTournamentsQueryDto());
+
+        // Act
+        var result = await handler.Handle(query, default);
+
+        // Assert
+        result.Items.Count.Should().Be(2);
+        result.Items.Should().HaveCount(2);
+        result.Items.All(t => !string.IsNullOrWhiteSpace(t.Winner)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnEmptyList_WhenNoMatchesExist()
+    {
+        // Arrange
+        var paged = new PagedResultDto<Tournament>
+        {
+            Items = [],
+            TotalCount = 0
+        };
+
+        var repo = new Mock<ITournamentRepository>();
+        repo.Setup(r => r.GetFilteredAsync(It.IsAny<GetTournamentsQueryDto>(), default)).ReturnsAsync([]);
+
+        var handler = new GetTournamentsByFilterHandler(repo.Object);
+        var query = new GetTournamentsByFilterQuery(new GetTournamentsQueryDto());
+
+        // Act
+        var result = await handler.Handle(query, default);
+
+        // Assert
+        result.Items.Count.Should().Be(0);
+        result.Items.Should().BeEmpty();
+    }
+    
+
+}

--- a/tests/Challengers.UnitTests/Challengers.Domain/Entities/MatchTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Domain/Entities/MatchTests.cs
@@ -1,0 +1,170 @@
+﻿using Challengers.Domain.Entities;
+using Challengers.Domain.Enums;
+using Challengers.Domain.Services;
+using Challengers.UnitTests.TestHelpers;
+using FluentAssertions;
+using Moq;
+using Match = Challengers.Domain.Entities.Match;
+
+namespace Challengers.UnitTests.Challengers.Domain.Entities;
+public class MatchTests
+{
+    private readonly Mock<IRandomGenerator> _randomMock;
+
+    public MatchTests()
+    {
+        _randomMock = new Mock<IRandomGenerator>();
+    }
+
+    [Fact]
+    public void Play_ShouldReturnPlayerWithHigherSkill_WhenLuckIsEqual()
+    {
+        // Arrange
+        var player1 = new MalePlayer("Player", "One", 90, 70, 70);
+        var player2 = new MalePlayer("Player", "Two", 70, 60, 60).WithRandomId();
+
+        _randomMock.Setup(r => r.NextDouble()).Returns(0.5);
+
+        var match = new Match(player1, player2, _randomMock.Object);
+
+        // Act
+        match.Simulate();
+
+        // Assert
+        match.Winner.Should().Be(player1);
+    }
+
+    [Fact]
+    public void Play_ShouldReturnUnderdog_WhenLuckIsHighForHim()
+    {
+        // Arrange
+        var player1 = new FemalePlayer("Top", "Player", 90, 90);
+        var player2 = new FemalePlayer("Lucky", "Player", 10, 10).WithRandomId();
+
+        _randomMock.SetupSequence(r => r.NextDouble())
+            .Returns(0.1)
+            .Returns(0.9);
+
+        var match = new Match(player1, player2, _randomMock.Object);
+
+        // Act
+        match.Simulate();
+
+        // Assert
+        match.Winner.Should().Be(player2);
+    }
+
+    [Fact]
+    public void Play_ShouldSelectWinnerById_WhenScoresAreExactlyEqual()
+    {
+        // Arrange
+        var guid1 = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var guid2 = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var player1 = new FemalePlayer("Same", "Stats", 80, 80).WithId(guid1);
+        var player2 = new FemalePlayer("Same", "Stats", 80, 80).WithId(guid2);
+
+        _randomMock.SetupSequence(r => r.NextDouble())
+            .Returns(0.5)
+            .Returns(0.5);
+
+        var match = new Match(player1, player2, _randomMock.Object);
+
+        // Act
+        match.Simulate();
+
+        // Assert
+        match.Winner.Should().Be(player1);
+    }
+
+    [Fact]
+    public void Simulate_ShouldThrow_WhenCalledTwice()
+    {
+        // Arrange
+        var player1 = new FemalePlayer("Ana", "Uno", 80, 80);
+        var player2 = new FemalePlayer("Laura", "Dos", 80, 80).WithRandomId();
+
+        var match = new Match(player1, player2, _randomMock.Object);
+        match.Simulate();
+
+        // Act
+        Action act = () => match.Simulate();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*already*");
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenPlayer1IsNull()
+    {
+        // Arrange
+        var player2 = new FemalePlayer("Laura", "Dos", 80, 80);
+
+        // Act
+        Action act = () => new Match(null!, player2);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*players*");
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenPlayer2IsNull()
+    {
+        // Arrange
+        var player1 = new FemalePlayer("Ana", "Uno", 80, 80);
+
+        // Act
+        Action act = () => new Match(player1, null!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*players*");
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenPlayersHaveSameId()
+    {
+        // Arrange
+        var player = new FemalePlayer("Ana", "Uno", 80, 80);
+
+        // Act
+        Action act = () => new Match(player, player);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*themselves*");
+    }
+
+    [Fact]
+    public void SetTournament_ShouldAssignTournamentToMatch()
+    {
+        // Arrange
+        var player1 = new FemalePlayer("Ana", "1", 80, 80);
+        var player2 = new FemalePlayer("Laura", "2", 80, 80).WithRandomId();
+
+        var tournament = new Tournament("Test", Gender.Female, new List<Player> { player1, player2 });
+
+        var match = new Match(player1, player2, _randomMock.Object);
+        // Act
+        match.SetTournament(tournament);
+        // Assert
+        match.Tournament.Should().Be(tournament);
+        match.TournamentId.Should().Be(tournament.Id);
+    }
+
+    [Fact]
+    public void SetTournament_ShouldThrow_WhenNull()
+    {
+        // Arrange
+        var player1 = new FemalePlayer("Ana", "1", 80, 80);
+        var player2 = new FemalePlayer("Laura", "2", 80, 80).WithRandomId();
+        // Act
+        var match = new Match(player1, player2, _randomMock.Object);
+
+        Action act = () => match.SetTournament(null!);
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+}

--- a/tests/Challengers.UnitTests/Challengers.Domain/Entities/PlayerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Domain/Entities/PlayerTests.cs
@@ -1,0 +1,139 @@
+﻿using Challengers.Domain.Entities;
+using FluentAssertions;
+using System.Globalization;
+
+namespace Challengers.UnitTests.Challengers.Domain.Entities;
+
+public class PlayerTests
+{
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(101)]
+    public void FemalePlayer_ShouldThrow_WhenSkillIsOutOfRange(int invalidSkill)
+    {
+        // Arrange & Act
+        Action act = () => new FemalePlayer("Ana", "Perez", invalidSkill, 80);
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+           .Where(e => e.ParamName == "skill");
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(101)]
+    public void FemalePlayer_ShouldThrow_WhenReactionTimeIsOutOfRange(int invalidReaction)
+    {
+        // Arrange & Act
+        Action act = () => new FemalePlayer("Ana", "Perez", 80, invalidReaction);
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+           .Where(e => e.ParamName == "reactionTime");
+    }
+
+    [Theory]
+    [InlineData(-1, 80)]
+    [InlineData(80, -1)]
+    [InlineData(101, 80)]
+    [InlineData(80, 101)]
+    public void MalePlayer_ShouldThrow_WhenStrengthOrSpeedIsOutOfRange(int strength, int speed)
+    {
+        // Arrange & Act
+        Action act = () => new MalePlayer("Juan", "Lopez", 80, strength, speed);
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Theory]
+    [InlineData(null, "Surname")]
+    [InlineData("Name", null)]
+    [InlineData("", "Surname")]
+    [InlineData("Name", "")]
+    public void FemalePlayer_ShouldThrow_WhenNameOrSurnameInvalid(string? name, string? surname)
+    {
+        // Arrange & Act
+        Action act = () => new FemalePlayer(name!, surname!, 80, 80);
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void ExplainScore_ShouldIncludeAllComponents_ForFemalePlayer()
+    {
+        // Arrange
+        var player = new FemalePlayer("Ana", "Perez", 80, 70);
+        var luck = 0.5;
+        var expectedScore = player.GetMatchScore(luck);
+
+        // Act
+        var explanation = player.ExplainScore(expectedScore, luck);
+
+        // Assert
+        explanation.Should().Contain("80")        // Skill
+                   .And.Contain("70")             // ReactionTime
+                   .And.Contain("0.5")            // Luck
+                   .And.Contain(expectedScore.ToString()); // Final score
+    }
+    [Fact]
+    public void ExplainScore_ShouldIncludeAllComponents_ForMalePlayer()
+    {
+        // Arrange
+        var player = new MalePlayer("Juan", "Gomez", 85, 75, 65);
+        var luck = 0.4;
+        var expectedScore = player.GetMatchScore(luck);
+        
+        // Act
+        var explanation = player.ExplainScore(expectedScore, luck);
+
+        // Assert
+        explanation.Should().Contain("85")       // Skill
+                   .And.Contain("75")            // Strength
+                   .And.Contain("65")            // Speed
+                   .And.Contain("0.4")           // Luck
+                   .And.Contain(expectedScore.ToString()); // Final score
+    }
+
+    [Fact]
+    public void SetName_ShouldUpdatePlayerName()
+    {
+        // Arrange
+        var player = new FemalePlayer("Ana", "Perez", 80, 80);
+        // Act
+        player.SetName("Laura");
+        // Assert   
+        player.Name.Should().Be("Laura");
+    }
+
+    [Fact]
+    public void SetSurname_ShouldUpdatePlayerSurname()
+    {
+        // Arrange
+        var player = new FemalePlayer("Ana", "Perez", 80, 80);
+        // Act
+        player.SetSurname("Gomez");
+        // Assert
+        player.Surname.Should().Be("Gomez");
+    }
+
+    [Fact]
+    public void SetSkill_ShouldUpdatePlayerSkill()
+    {
+        // Arrange
+        var player = new FemalePlayer("Ana", "Perez", 80, 80);
+        // Act
+        player.SetSkill(90);
+        // Assert
+        player.Skill.Should().Be(90);
+    }
+
+    [Fact]
+    public void GetFullName_ShouldReturnConcatenatedName()
+    {
+        // Arrange
+        var player = new FemalePlayer("Ana", "Perez", 80, 80);
+        // Act
+        var fullName = player.GetFullName();
+        // Assert
+        fullName.Should().Be("Ana Perez");
+    }
+
+}

--- a/tests/Challengers.UnitTests/Challengers.Domain/Entities/TournamentTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Domain/Entities/TournamentTests.cs
@@ -1,0 +1,324 @@
+﻿using Challengers.Domain.Entities;
+using Challengers.Domain.Enums;
+using Challengers.Domain.Services;
+using Challengers.UnitTests.TestHelpers;
+using FluentAssertions;
+using Moq;
+
+namespace Challengers.UnitTests.Challengers.Domain.Entities;
+
+public class TournamentTests
+{
+    private readonly Mock<IRandomGenerator> _randomMock;
+
+    public TournamentTests()
+    {
+        _randomMock = new Mock<IRandomGenerator>();
+    }
+
+    [Fact]
+    public void Simulate_ShouldSetWinner_WhenTwoPlayersCompete()
+    {
+        // Arrange 
+        var player1 = new FemalePlayer("Superior", "One", 90, 90);
+        var player2 = new FemalePlayer("Inferior", "Two", 60, 60).WithRandomId();
+
+        _randomMock.SetupSequence(r => r.NextDouble())
+            .Returns(0.5)
+            .Returns(0.4);
+
+        var tournament = new Tournament("Test Tournament", Gender.Female, [player1, player2]);
+
+        // Act
+        tournament.Simulate(_randomMock.Object);
+
+        // Assert
+        var winner = tournament.Winner;
+        winner.Should().Be(player1);
+        tournament.IsCompleted.Should().BeTrue();
+        tournament.Matches.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Simulate_ShouldCompleteTournament_WhenPlayersAreFour()
+    {
+        // Arrange
+        var players = new List<Player>
+        {
+            new FemalePlayer("Player", "1", 90, 90),
+            new FemalePlayer("Player", "2", 80, 80),
+            new FemalePlayer("Player", "3", 70, 70),
+            new FemalePlayer("Player", "4", 60, 60),
+        };
+
+        for (int i = 0; i < players.Count; i++)
+        {
+            players[i].WithRandomId();
+        }
+
+        _randomMock.SetupSequence(r => r.NextDouble())
+            .Returns(0.5).Returns(0.4)
+            .Returns(0.3).Returns(0.2)
+            .Returns(0.6).Returns(0.4);
+
+        var tournament = new Tournament("Test Tournament", Gender.Female, players);
+
+        // Act
+        tournament.Simulate(_randomMock.Object);
+
+        // Assert
+        tournament.IsCompleted.Should().BeTrue();
+        tournament.Winner.Should().NotBeNull();
+        tournament.Matches.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void Simulate_ShouldThrowException_WhenAlreadySimulated()
+    {
+        // Arrange
+        var player1 = new FemalePlayer("A", "One", 80, 80);
+        var player2 = new FemalePlayer("B", "Two", 80, 80).WithRandomId();
+
+        var tournament = new Tournament("Test Tournament", Gender.Female, [player1, player2]);
+
+        tournament.Simulate(_randomMock.Object);
+
+        // Act
+        Action act = () => tournament.Simulate(_randomMock.Object);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*already*");
+    }
+
+    [Fact]
+    public void Simulate_ShouldCompleteTournament_WhenPlayersAreEight()
+    {
+        // Arrange
+        var players = new List<Player>
+        {
+            new MalePlayer("Player", "1", 90, 90, 90),
+            new MalePlayer("Player", "2", 85, 85, 85),
+            new MalePlayer("Player", "3", 80, 80, 80),
+            new MalePlayer("Player", "4", 75, 75, 75),
+            new MalePlayer("Player", "5", 70, 70, 70),
+            new MalePlayer("Player", "6", 65, 65, 65),
+            new MalePlayer("Player", "7", 60, 60, 60),
+            new MalePlayer("Player", "8", 55, 55, 55),
+        };
+
+        foreach (var player in players)
+        {
+            typeof(Player).GetProperty(nameof(Player.Id))!
+                .SetValue(player, Guid.NewGuid());
+        }
+
+        var luckValues = Enumerable.Range(0, 14).Select(_ => 0.5).ToArray();
+        _randomMock.SetupRepeatedReturns(14);
+
+        var tournament = new Tournament("Complete Tournament", Gender.Male, players);
+
+        // Act
+        tournament.Simulate(_randomMock.Object);
+
+        // Assert
+        tournament.IsCompleted.Should().BeTrue();
+        tournament.Winner.Should().NotBeNull();
+        tournament.Matches.Should().HaveCount(7); // 4 + 2 + 1
+    }
+
+    [Fact]
+    public void Simulate_ShouldDetermineWinnerBasedOnLuck_WhenPlayersAreEqual()
+    {
+        // Arrange
+        var players = new List<Player>
+        {
+            new MalePlayer("Player", "1", 80, 80, 80),
+            new MalePlayer("Player", "2", 80, 80, 80),
+            new MalePlayer("Player", "3", 80, 80, 80),
+            new MalePlayer("Player", "4", 80, 80, 80),
+            new MalePlayer("Player", "5", 80, 80, 80),
+            new MalePlayer("Player", "6", 80, 80, 80),
+            new MalePlayer("Player", "7", 80, 80, 80),
+            new MalePlayer("Player", "8", 80, 80, 80),
+        };
+
+        for (int i = 0; i < players.Count; i++)
+        {
+            typeof(Player).GetProperty(nameof(Player.Id))!
+                .SetValue(players[i], Guid.NewGuid());
+        }
+
+        var luckValues = new[]
+        {
+            0.5, 0.4, // Match 1: P1 wins
+            0.6, 0.3, // Match 2: P3 wins
+            0.2, 0.7, // Match 3: P4 wins
+            0.9, 0.1, // Match 4: P5 wins
+            0.8, 0.5, // SF1: P1 vs P3 → P1 wins
+            0.6, 0.4, // SF2: P4 vs P5 → P4 wins
+            0.9, 0.6  // Final: P1 vs P4 → P1 wins
+        };
+
+        _randomMock.SetupReturnsFromList(luckValues);
+
+        var tournament = new Tournament("Luck Tournament", Gender.Male, players);
+
+        // Act
+        tournament.Simulate(_randomMock.Object);
+
+        // Assert
+        tournament.IsCompleted.Should().BeTrue();
+        tournament.Matches.Should().HaveCount(7);
+        tournament.Winner.Should().NotBeNull();
+        tournament.Winner!.Name.Should().Be("Player");
+        tournament.Winner!.Surname.Should().Be("1");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_ShouldThrow_WhenNameIsInvalid(string? name)
+    {
+        // Arrange
+        var players = new List<Player>
+        {
+            new FemalePlayer("Ana", "1", 80, 80),
+            new FemalePlayer("Laura", "2", 80, 80)
+        };
+
+        // Act
+        Action act = () => new Tournament(name!, Gender.Female, players);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*name*");
+    }
+    [Fact]
+    public void Constructor_ShouldThrow_WhenGenderIsInvalid()
+    {
+        // Arrange
+        var players = new List<Player>
+        {
+            new FemalePlayer("Ana", "1", 80, 80),
+            new FemalePlayer("Laura", "2", 80, 80)
+        };
+
+        // Act
+        Action act = () => new Tournament("Invalid Gender", (Gender)99, players);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*gender*");
+    }
+    [Theory]
+    [InlineData(0)]
+    [InlineData(3)]
+    [InlineData(5)]
+    public void Constructor_ShouldThrow_WhenPlayerCountIsNotPowerOfTwo(int playerCount)
+    {
+        // Arrange
+        var players = Enumerable.Range(1, playerCount)
+            .Select(i => new FemalePlayer($"Player", $"{i}", 80, 80))
+            .Cast<Player>()
+            .ToList();
+
+        // Act
+        Action act = () => new Tournament("Invalid Players", Gender.Female, players);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*power of two*");
+    }
+    [Fact]
+    public void Simulate_ShouldThrow_WhenTournamentAlreadySimulated()
+    {
+        // Arrange
+        var players = new List<Player>
+        {
+            new FemalePlayer("Ana", "1", 80, 80),
+            new FemalePlayer("Laura", "2", 80, 80).WithRandomId()
+        };
+        var tournament = new Tournament("Torneo", Gender.Female, players);
+        tournament.Simulate(_randomMock.Object);
+
+        // Act
+        Action act = () => tournament.Simulate(_randomMock.Object);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*already*");
+    }
+
+    [Theory]
+    [InlineData(2, 1)]
+    [InlineData(4, 3)]
+    [InlineData(8, 7)]
+    public void Simulate_ShouldCreateCorrectNumberOfMatches(int playerCount, int expectedMatches)
+    {
+        // Arrange
+        var players = Enumerable.Range(1, playerCount)
+            .Select(i => new FemalePlayer("Player", i.ToString(), 80, 80))
+            .Cast<Player>()
+            .ToList();
+
+        foreach (var p in players)
+            typeof(Player).GetProperty(nameof(Player.Id))!.SetValue(p, Guid.NewGuid());
+
+        _randomMock.SetupRepeatedReturns(playerCount - 1 * 2);
+
+        var tournament = new Tournament("Test", Gender.Female, players);
+        // Act
+        tournament.Simulate(_randomMock.Object);
+        // Assert
+        tournament.Matches.Should().HaveCount(expectedMatches);
+    }
+
+    [Fact]
+    public void Simulate_ShouldSelectWinnerFromInitialPlayers()
+    {
+        // Arrange
+        var players = Enumerable.Range(1, 4)
+            .Select(i => new MalePlayer("Player", i.ToString(), 80, 80, 80))
+            .Cast<Player>()
+            .ToList();
+
+        foreach (var p in players)
+            typeof(Player).GetProperty(nameof(Player.Id))!.SetValue(p, Guid.NewGuid());
+
+        _randomMock.SetupRepeatedReturns(6); // 3 matches × 2 lucks
+        // Act
+        var tournament = new Tournament("Test", Gender.Male, players);
+        tournament.Simulate(_randomMock.Object);
+        // Assert
+        tournament.Winner.Should().NotBeNull();
+        tournament.Players.Should().Contain(tournament.Winner!);
+    }
+
+    [Fact]
+    public void Simulate_ShouldIncludeAllPlayersInMatches()
+    {
+        // Arrange
+        var players = Enumerable.Range(1, 4)
+            .Select(i => new FemalePlayer("P", i.ToString(), 80, 80))
+            .Cast<Player>()
+            .ToList();
+
+        foreach (var p in players)
+            typeof(Player).GetProperty(nameof(Player.Id))!.SetValue(p, Guid.NewGuid());
+
+        _randomMock.SetupRepeatedReturns(6); // 3 matches × 2
+
+        var tournament = new Tournament("Test", Gender.Female, players);
+        // Act
+        tournament.Simulate(_randomMock.Object);
+
+        var idsInMatches = tournament.Matches
+            .SelectMany(m => new[] { m.Player1Id, m.Player2Id, m.WinnerId!.Value });
+
+        var allPlayerIds = players.Select(p => p.Id);
+        // Assert
+        idsInMatches.Should().Contain(allPlayerIds);
+    }
+}

--- a/tests/Challengers.UnitTests/Challengers.UnitTests.csproj
+++ b/tests/Challengers.UnitTests/Challengers.UnitTests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="8.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Challengers.Application\Challengers.Application.csproj" />
+    <ProjectReference Include="..\..\src\Challengers.Domain\Challengers.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Challengers.UnitTests/TestHelpers/MoqExtensions.cs
+++ b/tests/Challengers.UnitTests/TestHelpers/MoqExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Challengers.Domain.Services;
+using Moq;
+
+namespace Challengers.UnitTests.TestHelpers;
+
+public static class MoqExtensions
+{
+    public static void SetupRepeatedReturns(this Mock<IRandomGenerator> mock, int count, double value = 0.5)
+    {
+        var sequence = mock.SetupSequence(r => r.NextDouble());
+        for (int i = 0; i < count; i++)
+        {
+            sequence = sequence.Returns(value);
+        }
+    }
+    public static void SetupReturnsFromList(this Mock<IRandomGenerator> mock, IEnumerable<double> values)
+    {
+        var sequence = mock.SetupSequence(r => r.NextDouble());
+        foreach (var value in values)
+        {
+            sequence = sequence.Returns(value);
+        }
+    }
+}

--- a/tests/Challengers.UnitTests/TestHelpers/TestHelper.cs
+++ b/tests/Challengers.UnitTests/TestHelpers/TestHelper.cs
@@ -1,0 +1,30 @@
+﻿using Challengers.Domain.Common;
+using Challengers.Domain.Entities;
+
+namespace Challengers.UnitTests.TestHelpers;
+
+public static class TestHelper
+{
+    public static T WithId<T>(this T entity, Guid id) where T : Entity<Guid>
+    {
+        typeof(T).GetProperty(nameof(Entity<Guid>.Id))!
+            .SetValue(entity, id);
+        return entity;
+    }
+
+    public static T WithRandomId<T>(this T entity) where T : Entity<Guid> => entity.WithId(Guid.NewGuid());
+
+    public static List<Player> FakePlayers(bool Male, int count)
+    {
+        return [.. Enumerable.Range(1, count).Select<int, Player>(i =>
+            Male
+                ? new MalePlayer($"P{i}", $"M{i}", 80, 70, 60).WithRandomId()
+                : new FemalePlayer($"P{i}", $"F{i}", 80, 75).WithRandomId()
+        )];
+    }
+
+    public static Tournament SimulateAndReturn(this Tournament t)
+    {
+        t.Simulate(); return t;
+    }
+}


### PR DESCRIPTION
Adds full test coverage for domain and application handlers (players and tournaments). Also refactors simulation randomness and moves pagination to the handler level.

## Includes:

- Refactored domain entities to use IRandomGenerator instead of generating luck internally
- Standardized the use of WithRandomId() in unit tests
- Added all missing unit tests for Player, Match, Tournament and their handlers (create, update, delete, get, filter, simulate)
- Pagination is now handled in the application layer (handlers) instead of the repositories
- Some validation messages were cleaned up and moved to resource files

