### PR TITLE
CI/CD layer: add Dockerfile.azure for production builds

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -34,7 +34,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./src/Challengers.Api
-          file: ./src/Challengers.Api/Dockerfile
+          file: ./src/Challengers.Api/Dockerfile.azure
           push: true
           tags: |
             simonholmquist/challengers-api:latest

--- a/src/Challengers.Api/Dockerfile
+++ b/src/Challengers.Api/Dockerfile
@@ -6,19 +6,15 @@ EXPOSE 80
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
-# Copiar toda la solución
 COPY . .
 
-# Restaurar dependencias y construir
 ENV EnableSourceControlManagerQueries=false
 RUN dotnet restore "src/Challengers.Api/Challengers.Api.csproj"
 RUN dotnet build "src/Challengers.Api/Challengers.Api.csproj" -c Release -o /app/build
 
-# Publicar
 FROM build AS publish
 RUN dotnet publish "src/Challengers.Api/Challengers.Api.csproj" -c Release -o /app/publish
 
-# Imagen final
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .

--- a/src/Challengers.Api/Dockerfile.azure
+++ b/src/Challengers.Api/Dockerfile.azure
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 80
+EXPOSE 443
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["Challengers.Api.csproj", "."]
+RUN dotnet restore "Challengers.Api.csproj"
+COPY . .
+RUN dotnet build "Challengers.Api.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "Challengers.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "Challengers.Api.dll"]


### PR DESCRIPTION
This PR introduces a dedicated `Dockerfile.azure` for production builds in CI/CD, keeping the default Dockerfile clean for local development.

### Changes:
- Created `Dockerfile.azure` with corrected paths for scoped build context
- Updated GitHub Actions workflow to use this file

This ensures isolated configuration between dev and CI environments without breaking local workflows.
