### PR TITLE
CI/CD layer: include full solution context in Docker build

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: ./src/Challengers.Api
+          context: ./src/
           file: ./src/Challengers.Api/Dockerfile.azure
           push: true
           tags: |

--- a/src/Challengers.Api/Dockerfile.azure
+++ b/src/Challengers.Api/Dockerfile.azure
@@ -5,9 +5,14 @@ EXPOSE 443
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
-COPY ["Challengers.Api.csproj", "."]
-RUN dotnet restore "Challengers.Api.csproj"
+COPY ["Challengers.Api/Challengers.Api.csproj", "Challengers.Api/"]
+COPY ["Challengers.Application/Challengers.Application.csproj", "Challengers.Application/"]
+COPY ["Challengers.Domain/Challengers.Domain.csproj", "Challengers.Domain/"]
+COPY ["Challengers.Infrastructure/Challengers.Infrastructure.csproj", "Challengers.Infrastructure/"]
+COPY ["Challengers.Shared/Challengers.Shared.csproj", "Challengers.Shared/"]
+RUN dotnet restore "Challengers.Api/Challengers.Api.csproj"
 COPY . .
+WORKDIR "/src/Challengers.Api"
 RUN dotnet build "Challengers.Api.csproj" -c Release -o /app/build
 
 FROM build AS publish


### PR DESCRIPTION
This PR fixes the build errors in CI by changing the Docker build context from `src/Challengers.Api` to `src/`, allowing all referenced projects to be available during restore and build.

### Changes:
- Updated `context` in GitHub Actions to `./src`
- Adjusted `Dockerfile.azure` to restore and build from full solution context
- Ensures correct paths to:
  - Challengers.Application
  - Challengers.Domain
  - Challengers.Infrastructure
  - Challengers.Shared

With these changes, the Docker image now builds successfully with all project references resolved, enabling correct deployment to Azure.
