### PR TITLE
API layer: expose /version endpoint with build metadata

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -36,6 +36,8 @@ jobs:
           context: ./src/
           file: ./src/Challengers.Api/Dockerfile.azure
           push: true
+          build-args: |
+            GIT_COMMIT_SHA=${{ github.sha }}
           tags: |
             simonholmquist/challengers-api:latest
             simonholmquist/challengers-api:${{ github.sha }}

--- a/src/Challengers.Api/Dockerfile.azure
+++ b/src/Challengers.Api/Dockerfile.azure
@@ -21,4 +21,6 @@ RUN dotnet publish "Challengers.Api.csproj" -c Release -o /app/publish /p:UseApp
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+ARG GIT_COMMIT_SHA=unknown
+ENV GIT_COMMIT_SHA=$GIT_COMMIT_SHA
 ENTRYPOINT ["dotnet", "Challengers.Api.dll"]

--- a/src/Challengers.Api/Internal/VersionInfo.cs
+++ b/src/Challengers.Api/Internal/VersionInfo.cs
@@ -1,0 +1,9 @@
+﻿namespace Challengers.Api.Internal;
+
+public static class VersionInfo
+{
+    public static string Version => typeof(Program).Assembly
+        .GetName().Version?.ToString() ?? "unknown";
+
+    public static string CommitSha => Environment.GetEnvironmentVariable("GIT_COMMIT_SHA") ?? "unknown";
+}


### PR DESCRIPTION
This PR introduces a new `/version` endpoint to expose basic build metadata.

### Features:
- Returns the assembly version and the Git commit SHA
- Commit SHA is injected via Docker build-arg (`GIT_COMMIT_SHA`)
- Useful for verifying deployed image version in Azure

This change improves observability and allows post-deploy validation without inspecting Docker tags.
