### PR TITLE
API layer: fix missing registration of /version endpoint

### DIFF
--- a/src/Challengers.Api/Program.cs
+++ b/src/Challengers.Api/Program.cs
@@ -1,4 +1,5 @@
-﻿using Challengers.Api.Middleware;
+﻿using Challengers.Api.Internal;
+using Challengers.Api.Middleware;
 using Challengers.Application.Behaviors;
 using Challengers.Application.Features.Tournaments.Commands.CreateTournament;
 using Challengers.Application.Validators;
@@ -138,6 +139,11 @@ public class Program
         app.UseAuthentication();
         app.UseAuthorization();
         app.MapControllers();
+        app.MapGet("/version", () => new
+        {
+            version = VersionInfo.Version,
+            commit = VersionInfo.CommitSha
+        });
 
         using (var scope = app.Services.CreateScope())
         {


### PR DESCRIPTION
Fixes a missing change in `Program.cs` where the `/version` endpoint was not registered, resulting in a 404 in the deployed container.

This completes the addition of the versioning feature, making it accessible from:

GET /version