### PR TITLE
Refactor: rename Name/Surname to FirstName/LastName across solution

### DIFF
--- a/src/Challengers.Application/DTOs/CreatePlayerRequestDto.cs
+++ b/src/Challengers.Application/DTOs/CreatePlayerRequestDto.cs
@@ -4,12 +4,11 @@ namespace Challengers.Application.DTOs;
 
 public record class CreatePlayerRequestDto
 {
-    public string Name { get; init; } = default!;
-    public string Surname { get; init; } = default!;
+    public string FirstName { get; init; } = default!;
+    public string LastName { get; init; } = default!;
     public Gender Gender { get; init; }
     public int Skill { get; init; }
     public int? Strength { get; init; }
     public int? Speed { get; init; }
     public int? ReactionTime { get; init; }
 }
-

--- a/src/Challengers.Application/DTOs/GetPlayersQueryDto.cs
+++ b/src/Challengers.Application/DTOs/GetPlayersQueryDto.cs
@@ -5,7 +5,7 @@ namespace Challengers.Application.DTOs
     public record class GetPlayersQueryDto : PaginationQueryDto
     {
         public Gender? Gender { get; init; }
-        public string? Name { get; init; }
-        public string? Surname { get; init; }
+        public string? FirstName { get; init; }
+        public string? LastName { get; init; }
     }
 }

--- a/src/Challengers.Application/DTOs/PlayerDto.cs
+++ b/src/Challengers.Application/DTOs/PlayerDto.cs
@@ -5,9 +5,9 @@ namespace Challengers.Application.DTOs;
 public record class PlayerDto
 {
     public Guid? Id { get; init; }
-    public string? Name { get; init; }
-    public string? Surname { get; init; }
-    public string? FullName { get => $"{Name} {Surname}";}
+    public string? FirstName { get; init; }
+    public string? LastName { get; init; }
+    public string? FullName { get => $"{FirstName} {LastName}";}
     public int? Skill { get; init; }
     public int? Strength { get; init; }
     public int? Speed { get; init; }

--- a/src/Challengers.Application/DTOs/PlayerExcelDto.cs
+++ b/src/Challengers.Application/DTOs/PlayerExcelDto.cs
@@ -1,0 +1,14 @@
+﻿namespace Challengers.Application.DTOs;
+
+public record class PlayerExcelDto
+{
+    public string FirstName { get; set; } = default!;
+    public string LastName { get; set; } = default!;
+    public int Gender { get; set; }
+    public int? Skill { get; set; }
+    public int? Strength { get; set; }
+    public int? Speed { get; set; }
+    public int? ReactionTime { get; set; }
+    public int RowNumber { get; set; }
+}
+

--- a/src/Challengers.Application/DTOs/UpdatePlayerRequestDto.cs
+++ b/src/Challengers.Application/DTOs/UpdatePlayerRequestDto.cs
@@ -4,8 +4,8 @@ namespace Challengers.Application.DTOs;
 
 public record class UpdatePlayerRequestDto
 {
-    public string? Name { get; init; }
-    public string? Surname { get; init; }
+    public string? FirstName { get; init; }
+    public string? LastName { get; init; }
     public int? Skill { get; init; }
     public int? Strength { get; init; }
     public int? Speed { get; init; }

--- a/src/Challengers.Application/Features/Players/Commands/CreatePlayer/CreatePlayerHandler.cs
+++ b/src/Challengers.Application/Features/Players/Commands/CreatePlayer/CreatePlayerHandler.cs
@@ -17,8 +17,8 @@ public class CreatePlayerHandler(IPlayerRepository repository)
 
         Player player = dto.Gender switch
         {
-            Gender.Male => new MalePlayer(dto.Name, dto.Surname, dto.Skill, dto.Strength!.Value, dto.Speed!.Value),
-            Gender.Female => new FemalePlayer(dto.Name, dto.Surname, dto.Skill, dto.ReactionTime!.Value),
+            Gender.Male => new MalePlayer(dto.FirstName, dto.LastName, dto.Skill, dto.Strength!.Value, dto.Speed!.Value),
+            Gender.Female => new FemalePlayer(dto.FirstName, dto.LastName, dto.Skill, dto.ReactionTime!.Value),
             _ => throw new ArgumentException(ErrorMessages.InvalidGender())
         };
 

--- a/src/Challengers.Application/Features/Players/Commands/UpdatePlayer/UpdatePlayerHandler.cs
+++ b/src/Challengers.Application/Features/Players/Commands/UpdatePlayer/UpdatePlayerHandler.cs
@@ -22,8 +22,8 @@ public class UpdatePlayerHandler(IPlayerRepository repository) : IRequestHandler
         {
             Player replacement = dto.Gender.Value switch
             {
-                Gender.Male => new MalePlayer(dto.Name ?? existing.Name, dto.Surname ?? existing.Surname, dto.Skill ?? existing.Skill, dto.Strength!.Value, dto.Speed!.Value),
-                Gender.Female => new FemalePlayer(dto.Name ?? existing.Name, dto.Surname ?? existing.Surname, dto.Skill ?? existing.Skill, dto.ReactionTime!.Value),
+                Gender.Male => new MalePlayer(dto.FirstName ?? existing.FirstName, dto.LastName ?? existing.LastName, dto.Skill ?? existing.Skill, dto.Strength!.Value, dto.Speed!.Value),
+                Gender.Female => new FemalePlayer(dto.FirstName ?? existing.FirstName, dto.LastName ?? existing.LastName, dto.Skill ?? existing.Skill, dto.ReactionTime!.Value),
                 _ => throw new ArgumentException(ErrorMessages.InvalidGender())
             };
 
@@ -40,8 +40,8 @@ public class UpdatePlayerHandler(IPlayerRepository repository) : IRequestHandler
             return Unit.Value;
         }
 
-        if (!string.IsNullOrEmpty(dto.Name)) existing.SetName(dto.Name);
-        if (!string.IsNullOrEmpty(dto.Surname)) existing.SetSurname(dto.Surname);
+        if (!string.IsNullOrEmpty(dto.FirstName)) existing.SetName(dto.FirstName);
+        if (!string.IsNullOrEmpty(dto.LastName)) existing.SetLastName(dto.LastName);
         if (dto.Skill.HasValue) existing.SetSkill(dto.Skill.Value);
 
         if (existing is MalePlayer m && dto.Strength is not null && dto.Speed is not null)

--- a/src/Challengers.Application/Features/Players/Queries/GetPlayerById/GetPlayerByIdHandler.cs
+++ b/src/Challengers.Application/Features/Players/Queries/GetPlayerById/GetPlayerByIdHandler.cs
@@ -18,8 +18,8 @@ public class GetPlayerByIdHandler(IPlayerRepository repository)
         return new PlayerDto
         {
             Id = player.Id,
-            Name = player.Name,
-            Surname = player.Surname,
+            FirstName = player.FirstName,
+            LastName = player.LastName,
             Skill = player.Skill,
             Strength = player is MalePlayer m ? m.Strength : null,
             Speed = player is MalePlayer m2 ? m2.Speed : null,

--- a/src/Challengers.Application/Features/Players/Queries/GetPlayers/GetPlayersQueryHandler.cs
+++ b/src/Challengers.Application/Features/Players/Queries/GetPlayers/GetPlayersQueryHandler.cs
@@ -24,8 +24,8 @@ public class GetPlayersQueryHandler(IPlayerRepository repository) : IRequestHand
             .Select(p => new PlayerDto
             {
                 Id = p.Id,
-                Name = p.Name,
-                Surname = p.Surname,
+                FirstName = p.FirstName,
+                LastName = p.LastName,
                 Skill = p.Skill,
                 Strength = p is MalePlayer m ? m.Strength : null,
                 Speed = p is MalePlayer m2 ? m2.Speed : null,

--- a/src/Challengers.Application/Features/Tournaments/Commands/CreateTournament/CreateTournamentHandler.cs
+++ b/src/Challengers.Application/Features/Tournaments/Commands/CreateTournament/CreateTournamentHandler.cs
@@ -4,7 +4,6 @@ using Challengers.Domain.Entities;
 using Challengers.Domain.Enums;
 using Challengers.Shared.Helpers;
 using MediatR;
-using System.Collections.Generic;
 
 namespace Challengers.Application.Features.Tournaments.Commands.CreateTournament;
 
@@ -38,15 +37,15 @@ public class CreateTournamentHandler(ITournamentRepository tournamentRepository,
                 Player newPlayer = dto.Gender switch
                 {
                     Gender.Male => new MalePlayer(
-                        playerDto.Name!,
-                        playerDto.Surname!,
+                        playerDto.FirstName!,
+                        playerDto.LastName!,
                         playerDto.Skill!.Value,
                         playerDto.Strength!.Value,
                         playerDto.Speed!.Value),
 
                     Gender.Female => new FemalePlayer(
-                        playerDto.Name!,
-                        playerDto.Surname!,
+                        playerDto.FirstName!,
+                        playerDto.LastName!,
                         playerDto.Skill!.Value,
                         playerDto.ReactionTime!.Value),
 
@@ -63,7 +62,7 @@ public class CreateTournamentHandler(ITournamentRepository tournamentRepository,
         var mismatchedPlayers = players.Where(p => p.Gender != dto.Gender).ToList();
         if (mismatchedPlayers.Count != 0)
         {
-            var offendingNames = string.Join(", ", mismatchedPlayers.Select(p => p.GetFullName()));
+            var offendingNames = string.Join(", ", mismatchedPlayers.Select(p => p.FullName));
             throw new ArgumentException(FormatMessage(TournamentPlayersGenderMismatch, dto.Gender, offendingNames));
         }
 

--- a/src/Challengers.Application/Features/Tournaments/Commands/SimulateTournament/SimulateTournamentHandler.cs
+++ b/src/Challengers.Application/Features/Tournaments/Commands/SimulateTournament/SimulateTournamentHandler.cs
@@ -27,7 +27,7 @@ public class SimulateTournamentHandler(
         return new SimulateTournamentResponseDto
         {
             TournamentId = tournament.Id,
-            Winner = tournament.Winner?.GetFullName() ?? string.Empty
+            Winner = tournament.Winner?.FullName ?? string.Empty
         };
     }
 }

--- a/src/Challengers.Application/Features/Tournaments/Queries/GetTournamentResult/GetTournamentResultHandler.cs
+++ b/src/Challengers.Application/Features/Tournaments/Queries/GetTournamentResult/GetTournamentResultHandler.cs
@@ -22,7 +22,7 @@ public class GetTournamentResultHandler(
             Name = tournament.Name,
             Gender = tournament.Gender,
             CreatedAt = tournament.CreatedAt,
-            Winner = tournament.Winner?.GetFullName() ?? string.Empty
+            Winner = tournament.Winner?.FullName ?? string.Empty
         };
     }
 }

--- a/src/Challengers.Application/Features/Tournaments/Queries/GetTournamentsByFilter/GetTournamentsByFilterHandler.cs
+++ b/src/Challengers.Application/Features/Tournaments/Queries/GetTournamentsByFilter/GetTournamentsByFilterHandler.cs
@@ -29,7 +29,7 @@ public class GetTournamentsByFilterHandler(ITournamentRepository repository) : I
                 Name = t.Name,
                 Gender = t.Gender,
                 CreatedAt = t.CreatedAt,
-                Winner = t.Winner?.GetFullName() ?? string.Empty
+                Winner = t.Winner?.FullName ?? string.Empty
             })
             .ToList();
 

--- a/src/Challengers.Application/Validators/CreatePlayerRequestDtoValidator.cs
+++ b/src/Challengers.Application/Validators/CreatePlayerRequestDtoValidator.cs
@@ -8,13 +8,13 @@ public class CreatePlayerRequestDtoValidator : AbstractValidator<CreatePlayerReq
 {
     public CreatePlayerRequestDtoValidator()
     {
-        RuleFor(x => x.Name)
-            .NotEmpty().WithMessage(GetMessage(NameRequired))
-            .MaximumLength(MaxNameLength).WithMessage(GetMessage(NameTooLong));
+        RuleFor(x => x.FirstName)
+            .NotEmpty().WithMessage(GetMessage(FirstNameRequired))
+            .MaximumLength(MaxNameLength).WithMessage(GetMessage(FirstNameTooLong));
 
-        RuleFor(x => x.Surname)
-            .NotEmpty().WithMessage(GetMessage(SurnameRequired))
-            .MaximumLength(MaxSurnameLength).WithMessage(GetMessage(SurnameTooLong));
+        RuleFor(x => x.LastName)
+            .NotEmpty().WithMessage(GetMessage(LastNameRequired))
+            .MaximumLength(MaxLastNameLength).WithMessage(GetMessage(LastNameTooLong));
 
         RuleFor(x => x.Skill)
             .InclusiveBetween(MinStat, MaxStat)

--- a/src/Challengers.Application/Validators/GetPlayersQueryDtoValidator.cs
+++ b/src/Challengers.Application/Validators/GetPlayersQueryDtoValidator.cs
@@ -8,9 +8,9 @@ public class GetPlayersQueryDtoValidator : PaginationQueryDtoValidator<GetPlayer
 {
     public GetPlayersQueryDtoValidator()
     {
-        RuleFor(x => x.Name).MaximumLength(MaxNameLength).WithMessage(GetMessage(NameTooLong));
+        RuleFor(x => x.FirstName).MaximumLength(MaxNameLength).WithMessage(GetMessage(FirstNameTooLong));
 
-        RuleFor(x => x.Surname).MaximumLength(MaxSurnameLength).WithMessage(GetMessage(SurnameTooLong));
+        RuleFor(x => x.LastName).MaximumLength(MaxLastNameLength).WithMessage(GetMessage(LastNameTooLong));
 
         When(x => x.Gender.HasValue, () =>
         {

--- a/src/Challengers.Application/Validators/PlayerDtoValidator.cs
+++ b/src/Challengers.Application/Validators/PlayerDtoValidator.cs
@@ -10,15 +10,15 @@ public class PlayerDtoValidator : AbstractValidator<PlayerDto>
         RuleFor(x => x.Id)
             .NotEmpty().WithMessage(GetMessage(PlayerIdRequired));
 
-        RuleFor(x => x.Name)
+        RuleFor(x => x.FirstName)
             .MaximumLength(MaxNameLength)
-            .When(x => !string.IsNullOrWhiteSpace(x.Name))
-            .WithMessage(FormatMessage(NameTooLong, MaxNameLength));
+            .When(x => !string.IsNullOrWhiteSpace(x.FirstName))
+            .WithMessage(FormatMessage(FirstNameTooLong, MaxNameLength));
 
-        RuleFor(x => x.Surname)
-            .MaximumLength(MaxSurnameLength)
-            .When(x => !string.IsNullOrWhiteSpace(x.Name))
-            .WithMessage(FormatMessage(SurnameTooLong, MaxSurnameLength));
+        RuleFor(x => x.LastName)
+            .MaximumLength(MaxLastNameLength)
+            .When(x => !string.IsNullOrWhiteSpace(x.FirstName))
+            .WithMessage(FormatMessage(LastNameTooLong, MaxLastNameLength));
 
         RuleFor(x => x.Skill)
             .InclusiveBetween(MinStat, MaxStat)

--- a/src/Challengers.Application/Validators/PlayerReferenceOrCreateValidator.cs
+++ b/src/Challengers.Application/Validators/PlayerReferenceOrCreateValidator.cs
@@ -21,8 +21,8 @@ public class PlayerReferenceOrCreateValidator : AbstractValidator<PlayerDto>
         {
             var tempDto = new CreatePlayerRequestDto
             {
-                Name = dto.Name ?? string.Empty,
-                Surname = dto.Surname ?? string.Empty,
+                FirstName = dto.FirstName ?? string.Empty,
+                LastName = dto.LastName ?? string.Empty,
                 Skill = dto.Skill ?? MinStat,
                 Strength = dto.Strength,
                 Speed = dto.Speed,

--- a/src/Challengers.Domain/Constants/PlayerConstants.cs
+++ b/src/Challengers.Domain/Constants/PlayerConstants.cs
@@ -3,7 +3,7 @@
 public static class PlayerConstants
 {
     public const int MaxNameLength = 50;
-    public const int MaxSurnameLength = 50;
+    public const int MaxLastNameLength = 50;
     public const int MinStat = 0;
     public const int MaxStat = 100;
 

--- a/src/Challengers.Domain/Entities/FemalePlayer.cs
+++ b/src/Challengers.Domain/Entities/FemalePlayer.cs
@@ -7,8 +7,8 @@ public class FemalePlayer : Player
 {
     public int ReactionTime { get; private set; }
 
-    public FemalePlayer(string name, string surname, int skill, int reactionTime)
-        : base(name, surname, skill, Gender.Female)
+    public FemalePlayer(string firstName, string lastName, int skill, int reactionTime)
+        : base(firstName, lastName, skill, Gender.Female)
     {
         if (reactionTime is < MinStat or > MaxStat)
             throw new ArgumentOutOfRangeException(

--- a/src/Challengers.Domain/Entities/MalePlayer.cs
+++ b/src/Challengers.Domain/Entities/MalePlayer.cs
@@ -8,8 +8,8 @@ public class MalePlayer : Player
     public int Strength { get; private set; }
     public int Speed { get; private set; }
 
-    public MalePlayer(string name, string surname, int skill, int strength, int speed)
-        : base(name, surname, skill, Gender.Male)
+    public MalePlayer(string firstName, string lastName, int skill, int strength, int speed)
+        : base(firstName, lastName, skill, Gender.Male)
     {
         if (strength is < MinStat or > MaxStat)
             throw new ArgumentOutOfRangeException(

--- a/src/Challengers.Domain/Entities/Player.cs
+++ b/src/Challengers.Domain/Entities/Player.cs
@@ -6,25 +6,26 @@ namespace Challengers.Domain.Entities;
 
 public abstract class Player : Entity<Guid>
 {
-    public string Name { get; private set; } = default!;
-    public string Surname { get; private set; } = default!;
+    public string FirstName { get; private set; } = default!;
+    public string LastName { get; private set; } = default!;
+    public string FullName { get => $"{FirstName} {LastName}"; }
     public int Skill { get; private set; }
     public Gender Gender { get; private set; }
     public List<Tournament> Tournaments { get; private set; } = [];
-    protected Player(string name, string surname, int skill, Gender gender)
+    protected Player(string firstName, string lastName, int skill, Gender gender)
     {
-        if (string.IsNullOrWhiteSpace(name))
-            throw new ArgumentException(NameRequired, nameof(name));
+        if (string.IsNullOrWhiteSpace(firstName))
+            throw new ArgumentException(GetMessage(FirstNameRequired));
 
-        if (string.IsNullOrWhiteSpace(surname))
-            throw new ArgumentException(SurnameRequired, nameof(surname));
+        if (string.IsNullOrWhiteSpace(lastName))
+            throw new ArgumentException(GetMessage(LastNameRequired));
 
         if (skill is < MinStat or > MaxStat)
             throw new ArgumentOutOfRangeException(nameof(skill),
                 FormatMessage(SkillOutOfRange, MinStat, MaxStat));
 
-        Name = name;
-        Surname = surname;
+        FirstName = firstName;
+        LastName = lastName;
         Skill = skill;
         Gender = gender;
     }
@@ -41,8 +42,7 @@ public abstract class Player : Entity<Guid>
 
     protected abstract double CalculateScoreWithLuck(double luck);
     public abstract string ExplainScore(double score, double luck);
-    public void SetName(string name) => Name = name;
-    public void SetSurname(string surname) => Surname = surname;
+    public void SetName(string name) => FirstName = name;
+    public void SetLastName(string lastname) => LastName = lastname;
     public void SetSkill(int skill) => Skill = skill;
-    public string GetFullName() => $"{Name} {Surname}";
 }

--- a/src/Challengers.Infrastructure/Migrations/20250519061722_UseFirstNameAndLastName.Designer.cs
+++ b/src/Challengers.Infrastructure/Migrations/20250519061722_UseFirstNameAndLastName.Designer.cs
@@ -4,6 +4,7 @@ using Challengers.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Challengers.Infrastructure.Migrations
 {
     [DbContext(typeof(ChallengersDbContext))]
-    partial class ChallengersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250519061722_UseFirstNameAndLastName")]
+    partial class UseFirstNameAndLastName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Challengers.Infrastructure/Migrations/20250519061722_UseFirstNameAndLastName.cs
+++ b/src/Challengers.Infrastructure/Migrations/20250519061722_UseFirstNameAndLastName.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Challengers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class UseFirstNameAndLastName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "Surname",
+                table: "Players",
+                newName: "LastName");
+
+            migrationBuilder.RenameColumn(
+                name: "Name",
+                table: "Players",
+                newName: "FirstName");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "LastName",
+                table: "Players",
+                newName: "Surname");
+
+            migrationBuilder.RenameColumn(
+                name: "FirstName",
+                table: "Players",
+                newName: "Name");
+        }
+    }
+}

--- a/src/Challengers.Infrastructure/Persistence/Configurations/PlayerConfiguration.cs
+++ b/src/Challengers.Infrastructure/Persistence/Configurations/PlayerConfiguration.cs
@@ -12,13 +12,13 @@ public class PlayerConfiguration : IEntityTypeConfiguration<Player>
     {
         builder.HasKey(p => p.Id);
 
-        builder.Property(p => p.Name)
+        builder.Property(p => p.FirstName)
             .IsRequired()
             .HasMaxLength(PlayerConstants.MaxNameLength);
 
-        builder.Property(p => p.Surname)
+        builder.Property(p => p.LastName)
             .IsRequired()
-            .HasMaxLength(PlayerConstants.MaxSurnameLength);
+            .HasMaxLength(PlayerConstants.MaxLastNameLength);
 
         builder.Property(p => p.Skill)
             .IsRequired();

--- a/src/Challengers.Infrastructure/Persistence/Repositories/PlayerRepository.cs
+++ b/src/Challengers.Infrastructure/Persistence/Repositories/PlayerRepository.cs
@@ -11,7 +11,7 @@ public class PlayerRepository(ChallengersDbContext context)
     public async Task<List<Player>> GetPagedAsync(int page, int pageSize, CancellationToken cancellationToken)
     {
         return await _context.Players
-            .OrderBy(p => p.Name)
+            .OrderBy(p => p.FirstName)
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
             .ToListAsync(cancellationToken);
@@ -31,14 +31,14 @@ public class PlayerRepository(ChallengersDbContext context)
             query = query.Where(p => p.Gender == dto.Gender);
         }
 
-        if (!string.IsNullOrWhiteSpace(dto.Name))
+        if (!string.IsNullOrWhiteSpace(dto.FirstName))
         {
-            query = query.Where(p => p.Name.Contains(dto.Name));
+            query = query.Where(p => p.FirstName.Contains(dto.FirstName));
         }
 
-        if (!string.IsNullOrWhiteSpace(dto.Surname))
+        if (!string.IsNullOrWhiteSpace(dto.LastName))
         {
-            query = query.Where(p => p.Surname.Contains(dto.Surname));
+            query = query.Where(p => p.LastName.Contains(dto.LastName));
         }
 
         var players = await query.ToListAsync(cancellationToken);

--- a/src/Challengers.Infrastructure/Persistence/Repositories/TournamentRepository.cs
+++ b/src/Challengers.Infrastructure/Persistence/Repositories/TournamentRepository.cs
@@ -27,6 +27,7 @@ public class TournamentRepository(ChallengersDbContext context) : Repository<Tou
     public async Task<List<Tournament>> GetFilteredAsync(GetTournamentsQueryDto dto, CancellationToken cancellationToken)
     {
         var query = _context.Tournaments
+            .Include(t => t.Winner)
             .Include(t => t.Matches)
             .ThenInclude(m => m.Player1)
             .Include(t => t.Matches)

--- a/src/Challengers.Shared/Resources/MessageKeys.cs
+++ b/src/Challengers.Shared/Resources/MessageKeys.cs
@@ -8,10 +8,10 @@ public static class MessageKeys
     public const string Gender_Male = nameof(Gender_Male);
     public const string Gender_Female = nameof(Gender_Female);
 
-    public const string NameRequired = nameof(NameRequired);
-    public const string SurnameRequired = nameof(SurnameRequired);
-    public const string NameTooLong = nameof(NameTooLong);
-    public const string SurnameTooLong = nameof(SurnameTooLong);
+    public const string FirstNameRequired = nameof(FirstNameRequired);
+    public const string LastNameRequired = nameof(LastNameRequired);
+    public const string FirstNameTooLong = nameof(FirstNameTooLong);
+    public const string LastNameTooLong = nameof(LastNameTooLong);
     public const string PlayerIdRequired = nameof(PlayerIdRequired);
     public const string SkillOutOfRange = nameof(SkillOutOfRange);
     public const string StrengthOutOfRange = nameof(StrengthOutOfRange);

--- a/src/Challengers.Shared/Resources/Messages.Designer.cs
+++ b/src/Challengers.Shared/Resources/Messages.Designer.cs
@@ -79,6 +79,24 @@ namespace Challengers.Shared.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to First name cannot be empty..
+        /// </summary>
+        internal static string FirstNameRequired {
+            get {
+                return ResourceManager.GetString("FirstNameRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Player first name must be at most {0} characters..
+        /// </summary>
+        internal static string FirstNameTooLong {
+            get {
+                return ResourceManager.GetString("FirstNameTooLong", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to  Format error in message: {0}.
         /// </summary>
         internal static string FormatError {
@@ -133,6 +151,24 @@ namespace Challengers.Shared.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Player last name is required..
+        /// </summary>
+        internal static string LastNameRequired {
+            get {
+                return ResourceManager.GetString("LastNameRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Player last name must be at most {0} characters..
+        /// </summary>
+        internal static string LastNameTooLong {
+            get {
+                return ResourceManager.GetString("LastNameTooLong", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} * {1} (skill) + {2} * {3} (strength) + {4} * {5} (speed) + {6} * {7} (luck) = {8} total score.
         /// </summary>
         internal static string MaleScoreExplanation {
@@ -174,24 +210,6 @@ namespace Challengers.Shared.Resources {
         internal static string MixedGenderAttributes {
             get {
                 return ResourceManager.GetString("MixedGenderAttributes", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Name cannot be empty..
-        /// </summary>
-        internal static string NameRequired {
-            get {
-                return ResourceManager.GetString("NameRequired", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Player name must be at most {0} characters..
-        /// </summary>
-        internal static string NameTooLong {
-            get {
-                return ResourceManager.GetString("NameTooLong", resourceCulture);
             }
         }
         
@@ -327,24 +345,6 @@ namespace Challengers.Shared.Resources {
         internal static string StrengthRequiredForMale {
             get {
                 return ResourceManager.GetString("StrengthRequiredForMale", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Player surname is required..
-        /// </summary>
-        internal static string SurnameRequired {
-            get {
-                return ResourceManager.GetString("SurnameRequired", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Player surname must be at most {0} characters..
-        /// </summary>
-        internal static string SurnameTooLong {
-            get {
-                return ResourceManager.GetString("SurnameTooLong", resourceCulture);
             }
         }
         

--- a/src/Challengers.Shared/Resources/Messages.es.resx
+++ b/src/Challengers.Shared/Resources/Messages.es.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NameRequired" xml:space="preserve">
+  <data name="FirstNameRequired" xml:space="preserve">
     <value>El nombre no puede estar vacío.</value>
   </data>
   <data name="ReactionOutOfRange" xml:space="preserve">
@@ -204,13 +204,13 @@
   <data name="MixedGenderAttributes" xml:space="preserve">
     <value>Un jugador no puede tener tiempo de reacción y fuerza/velocidad.</value>
   </data>
-  <data name="SurnameRequired" xml:space="preserve">
+  <data name="LastNameRequired" xml:space="preserve">
     <value>Se requiere el apellido del jugador.</value>
   </data>
-  <data name="SurnameTooLong" xml:space="preserve">
+  <data name="LastNameTooLong" xml:space="preserve">
     <value>El apellido del jugador debe tener como máximo {0} caracteres.</value>
   </data>
-  <data name="NameTooLong" xml:space="preserve">
+  <data name="FirstNameTooLong" xml:space="preserve">
     <value>El nombre del jugador debe tener como máximo {0} caracteres.</value>
   </data>
   <data name="PlayerIdRequired" xml:space="preserve">

--- a/src/Challengers.Shared/Resources/Messages.resx
+++ b/src/Challengers.Shared/Resources/Messages.resx
@@ -117,8 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NameRequired" xml:space="preserve">
-    <value>Name cannot be empty.</value>
+  <data name="FirstNameRequired" xml:space="preserve">
+    <value>First name cannot be empty.</value>
   </data>
   <data name="ReactionOutOfRange" xml:space="preserve">
     <value>Reaction time must be between {0} and {1}.</value>
@@ -169,7 +169,7 @@
     <value>Tournament '{0}' created successfully.</value>
   </data>
   <data name="FormatError" xml:space="preserve">
-    <value> Format error in message: {0}</value>
+    <value>Format error in message: {0}</value>
   </data>
   <data name="TournamentNotFound" xml:space="preserve">
     <value>Tournament with ID {0} not found.</value>
@@ -204,14 +204,14 @@
   <data name="MixedGenderAttributes" xml:space="preserve">
     <value>A player cannot have both reaction time and strength/speed.</value>
   </data>
-  <data name="SurnameRequired" xml:space="preserve">
-    <value>Player surname is required.</value>
+  <data name="LastNameRequired" xml:space="preserve">
+    <value>Player last name is required.</value>
   </data>
-  <data name="SurnameTooLong" xml:space="preserve">
-    <value>Player surname must be at most {0} characters.</value>
+  <data name="LastNameTooLong" xml:space="preserve">
+    <value>Player last name must be at most {0} characters.</value>
   </data>
-  <data name="NameTooLong" xml:space="preserve">
-    <value>Player name must be at most {0} characters.</value>
+  <data name="FirstNameTooLong" xml:space="preserve">
+    <value>Player first name must be at most {0} characters.</value>
   </data>
   <data name="PlayerIdRequired" xml:space="preserve">
     <value>Player ID is required when referencing an existing player.</value>

--- a/tests/Challengers.AuthTests/AuthControllerTests.cs
+++ b/tests/Challengers.AuthTests/AuthControllerTests.cs
@@ -46,8 +46,8 @@ public class AuthControllerTests(CustomAuthWebApplicationFactoryForAuth factory)
         // Arrange
         var dto = new CreatePlayerRequestDto
         {
-            Name = "Infiltrado",
-            Surname = "NoAuth",
+            FirstName = "Infiltrado",
+            LastName = "NoAuth",
             Gender = Gender.Male,
             Skill = 70,
             Strength = 80,

--- a/tests/Challengers.UnitTests/Challengers.Api/Controllers/PlayersControllerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Api/Controllers/PlayersControllerTests.cs
@@ -17,15 +17,15 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
     };
 
     [Fact]
-    public async Task GetAll_ShouldFilterByGenderAndName()
+    public async Task GetAll_ShouldFilterByGenderAndFirstName()
     {
         // Arrange
         var uniqueName1 = $"Ana_{Guid.NewGuid().ToString("N")[..8]}";
         var uniqueName2 = $"Carlos_{Guid.NewGuid().ToString("N")[..8]}";
         var female1 = new CreatePlayerRequestDto
         {
-            Name = uniqueName1,
-            Surname = "Perez",
+            FirstName = uniqueName1,
+            LastName = "Perez",
             Gender = Gender.Female,
             Skill = 80,
             ReactionTime = 90
@@ -33,8 +33,8 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
 
         var male1 = new CreatePlayerRequestDto
         {
-            Name = uniqueName2,
-            Surname = "Lopez",
+            FirstName = uniqueName2,
+            LastName = "Lopez",
             Gender = Gender.Male,
             Skill = 85,
             Strength = 80,
@@ -45,7 +45,7 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
         await _client.PostAsJsonAsync("/api/players", male1);
 
         // Act
-        var response = await _client.GetAsync($"/api/players?gender=2&name={uniqueName1}");
+        var response = await _client.GetAsync($"/api/players?gender=2&firstname={uniqueName1}");
 
         // Assert
         response.EnsureSuccessStatusCode();
@@ -54,7 +54,7 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
         var paged = JsonSerializer.Deserialize<PagedResultDto<PlayerDto>>(raw, _jsonSerializerOptions);
 
         paged!.Items.Should().ContainSingle();
-        paged.Items[0].Name!.Should().Be(uniqueName1);
+        paged.Items[0].FirstName!.Should().Be(uniqueName1);
         paged.Items[0].Gender.Should().Be(Gender.Female);
     }
 
@@ -64,8 +64,8 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
         // Arrange
         var request = new CreatePlayerRequestDto
         {
-            Name = "Lucía",
-            Surname = "Martínez",
+            FirstName = "Lucía",
+            LastName = "Martínez",
             Gender = Gender.Female,
             Skill = 78,
             ReactionTime = 85
@@ -84,7 +84,7 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
 
         var paged = JsonSerializer.Deserialize<PagedResultDto<PlayerDto>>(listRaw, _jsonSerializerOptions);
 
-        paged!.Items.Should().ContainSingle(p => p.Name == "Lucía" && p.Surname == "Martínez");
+        paged!.Items.Should().ContainSingle(p => p.FirstName == "Lucía" && p.LastName == "Martínez");
     }
 
     [Fact]
@@ -93,8 +93,8 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
         // Arrange
         var request = new CreatePlayerRequestDto
         {
-            Name = "Carlos",
-            Surname = "Error",
+            FirstName = "Carlos",
+            LastName = "Error",
             Gender = Gender.Male,
             Skill = 105,
             Strength = null,
@@ -120,8 +120,8 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
         var uniqueName = $"Lucía_{Guid.NewGuid().ToString("N")[..8]}";
         var create = new CreatePlayerRequestDto
         {
-            Name = uniqueName,
-            Surname = "Martínez",
+            FirstName = uniqueName,
+            LastName = "Martínez",
             Gender = Gender.Female,
             Skill = 70,
             ReactionTime = 80
@@ -130,7 +130,7 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
         var createResponse = await _client.PostAsJsonAsync("/api/players", create);
         createResponse.EnsureSuccessStatusCode();
 
-        var listResponse = await _client.GetAsync($"/api/players?name={uniqueName}&page=1&pageSize=10");
+        var listResponse = await _client.GetAsync($"/api/players?firstname={uniqueName}&page=1&pageSize=10");
         var listRaw = await listResponse.Content.ReadAsStringAsync();
         var paged = JsonSerializer.Deserialize<PagedResultDto<PlayerDto>>(listRaw, _jsonSerializerOptions);
         var playerId = paged!.Items.Single().Id;
@@ -138,7 +138,7 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
         // Act
         var update = new UpdatePlayerRequestDto
         {
-            Name = "Luciana",
+            FirstName = "Luciana",
             Skill = 90
         };
 
@@ -152,19 +152,20 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
 
         var updated = JsonSerializer.Deserialize<PlayerDto>(updatedRaw, _jsonSerializerOptions);
 
-        updated!.Name.Should().Be("Luciana");
+        updated!.FirstName.Should().Be("Luciana");
         updated.Skill.Should().Be(90);
     }
 
     [Fact]
-    public async Task Put_ShouldUpdateOnlyName_WhenOtherFieldsMissing()
+    public async Task Put_ShouldUpdateOnlyFirstName_WhenOtherFieldsMissing()
     {
         // Arrange
-        var uniqueName = $"Lucía_{Guid.NewGuid().ToString("N")[..8]}";
+        var uniqueName1 = $"Lucía_{Guid.NewGuid().ToString("N")[..8]}";
+        var uniqueName2 = $"Luciana_{Guid.NewGuid().ToString("N")[..8]}";
         var create = new CreatePlayerRequestDto
         {
-            Name = uniqueName,
-            Surname = "Martínez",
+            FirstName = uniqueName1,
+            LastName = "Martínez",
             Gender = Gender.Female,
             Skill = 75,
             ReactionTime = 88
@@ -174,7 +175,7 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
 
         var update = new UpdatePlayerRequestDto
         {
-            Name = "Luciana"
+            FirstName = uniqueName2
         };
 
         // Act & Assert
@@ -182,8 +183,8 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
         putResponse.EnsureSuccessStatusCode();
 
         var updated = await TestHelper.GetPlayer(playerId.Value, _client);
-        updated.Name.Should().Be("Luciana");
-        updated.Surname.Should().Be("Martínez");
+        updated.FirstName.Should().Be(uniqueName2);
+        updated.LastName.Should().Be("Martínez");
         updated.Skill.Should().Be(75);
     }
 
@@ -193,8 +194,8 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
         // Arrange
         var create = new CreatePlayerRequestDto
         {
-            Name = "Pedro",
-            Surname = "Cambio",
+            FirstName = "Pedro",
+            LastName = "Cambio",
             Gender = Gender.Male,
             Skill = 80,
             Strength = 85,
@@ -224,10 +225,11 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
     public async Task Put_ShouldUpdateStrengthAndSpeed_WhenMale()
     {
         // Arrange
+        var uniqueName1 = $"Luis_{Guid.NewGuid().ToString("N")[..8]}";
         var create = new CreatePlayerRequestDto
         {
-            Name = "Luis",
-            Surname = "Fuerte",
+            FirstName = uniqueName1,
+            LastName = "Fuerte",
             Gender = Gender.Male,
             Skill = 70,
             Strength = 70,
@@ -257,8 +259,8 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
         // Arrange
         var create = new CreatePlayerRequestDto
         {
-            Name = "Juan",
-            Surname = "Error",
+            FirstName = "Juan",
+            LastName = "Error",
             Gender = Gender.Male,
             Skill = 70,
             Strength = 70,
@@ -285,8 +287,8 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
     {
         var create = new CreatePlayerRequestDto
         {
-            Name = "Carlos",
-            Surname = "Invalid",
+            FirstName = "Carlos",
+            LastName = "Invalid",
             Gender = Gender.Male,
             Skill = 80,
             Strength = 80,
@@ -314,8 +316,8 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
         var uniqueName = $"Carlos_{Guid.NewGuid():N}[..8]";
         var create = new CreatePlayerRequestDto
         {
-            Name = uniqueName,
-            Surname = "Borrable",
+            FirstName = uniqueName,
+            LastName = "Borrable",
             Gender = Gender.Male,
             Skill = 70,
             Strength = 80,
@@ -325,7 +327,7 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
         var createResponse = await _client.PostAsJsonAsync("/api/players", create);
         createResponse.EnsureSuccessStatusCode();
 
-        var getResponse = await _client.GetAsync($"/api/players?name={uniqueName}&page=1&pageSize=1");
+        var getResponse = await _client.GetAsync($"/api/players?firstname={uniqueName}&page=1&pageSize=1");
         var paged = await getResponse.Content.ReadFromJsonAsync<PagedResultDto<PlayerDto>>(_jsonSerializerOptions);
         var playerId = paged!.Items.Single().Id;
 
@@ -358,8 +360,8 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
         // Arrange
         var dto = new CreatePlayerRequestDto
         {
-            Name = "Carlos",
-            Surname = "Validez",
+            FirstName = "Carlos",
+            LastName = "Validez",
             Gender = Gender.Male,
             Skill = 80
         };
@@ -390,8 +392,8 @@ public class PlayersControllerTests(CustomWebApplicationFactory factory) : IClas
         // Arrange
         var dto = new CreatePlayerRequestDto
         {
-            Name = "Carlos",
-            Surname = "Validez",
+            FirstName = "Carlos",
+            LastName = "Validez",
             Gender = Gender.Male,
             Skill = 80
         };

--- a/tests/Challengers.UnitTests/Challengers.Api/Controllers/TournamentsControllerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Api/Controllers/TournamentsControllerTests.cs
@@ -20,8 +20,8 @@ public class TournamentsControllerTests(CustomWebApplicationFactory factory) : I
             savePlayers = false,
             players = new[]
             {
-                new { name = "Ana", surname = "Uno", skill = 80, reactionTime = 85, gender = 2 },
-                new { name = "Laura", surname = "Dos", skill = 85, reactionTime = 90, gender = 2 }
+                new { firstname = "Ana", lastname = "Uno", skill = 80, reactionTime = 85, gender = 2 },
+                new { firstname = "Laura", lastname = "Dos", skill = 85, reactionTime = 90, gender = 2 }
             }
         };
 
@@ -45,8 +45,8 @@ public class TournamentsControllerTests(CustomWebApplicationFactory factory) : I
             savePlayers = false,
             players = new[]
             {
-            new { name = "Juan", surname = "Uno", skill = 80, strength = 85, speed = 75, gender = 1 },
-            new { name = "Pedro", surname = "Dos", skill = 78, strength = 82, speed = 74, gender = 0 }
+            new { firstname = "Juan", lastname = "Uno", skill = 80, strength = 85, speed = 75, gender = 1 },
+            new { firstname = "Pedro", lastname = "Dos", skill = 78, strength = 82, speed = 74, gender = 0 }
         }
         };
 
@@ -76,8 +76,8 @@ public class TournamentsControllerTests(CustomWebApplicationFactory factory) : I
             savePlayers = false,
             players = new[]
             {
-            new { name = "Juan", surname = "Uno", skill = 80, strength = 85, speed = 75, gender = 1 },
-            new { name = "Pedro", surname = "Dos", skill = 78, strength = 82, speed = 74, gender = 1 }
+            new { firstname = "Juan", lastname = "Uno", skill = 80, strength = 85, speed = 75, gender = 1 },
+            new { firstname = "Pedro", lastname = "Dos", skill = 78, strength = 82, speed = 74, gender = 1 }
         }
         };
 
@@ -115,8 +115,8 @@ public class TournamentsControllerTests(CustomWebApplicationFactory factory) : I
             savePlayers = false,
             players = new[]
             {
-            new { name = "Ana", surname = "Uno", skill = 85, reactionTime = 90, gender = 2 },
-            new { name = "Laura", surname = "Dos", skill = 82, reactionTime = 88, gender = 2 }
+            new { firstname = "Ana", lastname = "Uno", skill = 85, reactionTime = 90, gender = 2 },
+            new { firstname = "Laura", lastname = "Dos", skill = 82, reactionTime = 88, gender = 2 }
         }
         };
 
@@ -127,8 +127,8 @@ public class TournamentsControllerTests(CustomWebApplicationFactory factory) : I
             savePlayers = false,
             players = new[]
             {
-            new { name = "Juan", surname = "Tres", skill = 80, strength = 85, speed = 75, gender = 1 },
-            new { name = "Pedro", surname = "Cuatro", skill = 78, strength = 82, speed = 74, gender = 1 }
+            new { firstname = "Juan", lastname = "Tres", skill = 80, strength = 85, speed = 75, gender = 1 },
+            new { firstname = "Pedro", lastname = "Cuatro", skill = 78, strength = 82, speed = 74, gender = 1 }
         }
         };
 

--- a/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Commands/CreatePlayer/CreatePlayerHandlerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Commands/CreatePlayer/CreatePlayerHandlerTests.cs
@@ -17,8 +17,8 @@ namespace Challengers.UnitTests.Challengers.Application.Features.Players.Command
             // Arrange
             var dto = new CreatePlayerRequestDto
             {
-                Name = "Juan",
-                Surname = "Pérez",
+                FirstName = "Juan",
+                LastName = "Pérez",
                 Gender = Gender.Male,
                 Skill = 80,
                 Strength = 85,
@@ -48,8 +48,8 @@ namespace Challengers.UnitTests.Challengers.Application.Features.Players.Command
             // Arrange
             var dto = new CreatePlayerRequestDto
             {
-                Name = "Ana",
-                Surname = "Lopez",
+                FirstName = "Ana",
+                LastName = "Lopez",
                 Gender = Gender.Female,
                 Skill = 90,
                 ReactionTime = 85
@@ -78,8 +78,8 @@ namespace Challengers.UnitTests.Challengers.Application.Features.Players.Command
             // Arrange
             var dto = new CreatePlayerRequestDto
             {
-                Name = "Alex",
-                Surname = "Test",
+                FirstName = "Alex",
+                LastName = "Test",
                 Gender = (Gender)99,
                 Skill = 80
             };

--- a/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Commands/UpdatePlayer/UpdatePlayerHandlerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Commands/UpdatePlayer/UpdatePlayerHandlerTests.cs
@@ -21,8 +21,8 @@ namespace Challengers.UnitTests.Challengers.Application.Features.Players.Command
 
             var dto = new UpdatePlayerRequestDto
             {
-                Name = "Carlos",
-                Surname = "Lopez",
+                FirstName = "Carlos",
+                LastName = "Lopez",
                 Skill = 90,
                 Strength = 85,
                 Speed = 75,
@@ -40,8 +40,8 @@ namespace Challengers.UnitTests.Challengers.Application.Features.Players.Command
             await handler.Handle(command, CancellationToken.None);
 
             // Assert
-            existing.Name.Should().Be("Carlos");
-            existing.Surname.Should().Be("Lopez");
+            existing.FirstName.Should().Be("Carlos");
+            existing.LastName.Should().Be("Lopez");
             existing.Skill.Should().Be(90);
             existing.Strength.Should().Be(85);
             existing.Speed.Should().Be(75);
@@ -60,8 +60,8 @@ namespace Challengers.UnitTests.Challengers.Application.Features.Players.Command
 
             var dto = new UpdatePlayerRequestDto
             {
-                Name = "Ana",
-                Surname = "Lopez",
+                FirstName = "Ana",
+                LastName = "Lopez",
                 Skill = 85,
                 ReactionTime = 90,
                 Gender = Gender.Female
@@ -80,8 +80,8 @@ namespace Challengers.UnitTests.Challengers.Application.Features.Players.Command
             // Assert
             repositoryMock.Verify(r => r.Delete(It.Is<Player>(p => p == existing)), Times.Once);
             repositoryMock.Verify(r => r.AddAsync(It.Is<FemalePlayer>(p =>
-                p.Name == "Ana" &&
-                p.Surname == "Lopez" &&
+                p.FirstName == "Ana" &&
+                p.LastName == "Lopez" &&
                 p.Skill == 85 &&
                 p.ReactionTime == 90 &&
                 p.Id == id
@@ -97,8 +97,8 @@ namespace Challengers.UnitTests.Challengers.Application.Features.Players.Command
             var id = Guid.NewGuid();
             var dto = new UpdatePlayerRequestDto
             {
-                Name = "Juan",
-                Surname = "Pérez",
+                FirstName = "Juan",
+                LastName = "Pérez",
                 Skill = 80,
                 Gender = Gender.Male,
                 Strength = 70,
@@ -130,8 +130,8 @@ namespace Challengers.UnitTests.Challengers.Application.Features.Players.Command
 
             var dto = new UpdatePlayerRequestDto
             {
-                Name = "Test",
-                Surname = "Test",
+                FirstName = "Test",
+                LastName = "Test",
                 Skill = 70,
                 Gender = (Gender)99
             };

--- a/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Queries/GetPlayerById/GetPlayerByIdHandlerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Queries/GetPlayerById/GetPlayerByIdHandlerTests.cs
@@ -29,7 +29,7 @@ public class GetPlayerByIdHandlerTests
         // Assert
         result.Should().NotBeNull();
         result.Id.Should().Be(id);
-        result.Name.Should().Be("Juan");
+        result.FirstName.Should().Be("Juan");
         result.Strength.Should().Be(70);
     }
 

--- a/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Queries/GetPlayers/GetPlayersQueryHandlerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Features/Players/Queries/GetPlayers/GetPlayersQueryHandlerTests.cs
@@ -56,7 +56,7 @@ public class GetPlayersQueryHandlerTests
                       .ReturnsAsync([]);
 
         var handler = new GetPlayersQueryHandler(repositoryMock.Object);
-        var query = new GetPlayersQuery(new GetPlayersQueryDto { Name = "NoExiste" });
+        var query = new GetPlayersQuery(new GetPlayersQueryDto { FirstName = "NoExiste" });
 
         var result = await handler.Handle(query, CancellationToken.None);
 
@@ -86,8 +86,8 @@ public class GetPlayersQueryHandlerTests
         var result = await handler.Handle(query, CancellationToken.None);
 
         result.Items.Should().ContainSingle(p =>
-            p.Name == "Carlos" &&
-            p.Surname == "Diaz" &&
+            p.FirstName == "Carlos" &&
+            p.LastName == "Diaz" &&
             p.Skill == 75 &&
             p.Strength == 70 &&
             p.Speed == 65

--- a/tests/Challengers.UnitTests/Challengers.Application/Features/Tournaments/Commands/CreateTournament/CreateTournamentHandlerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Features/Tournaments/Commands/CreateTournament/CreateTournamentHandlerTests.cs
@@ -22,8 +22,8 @@ public class CreateTournamentHandlerTests
             SavePlayers = true,
             Players =
             [
-                new() { Name = "Ana", Surname = "López", Skill = 85, ReactionTime = 80, Gender = Gender.Female },
-                new() { Name = "Laura", Surname = "Pérez", Skill = 88, ReactionTime = 82, Gender = Gender.Female }
+                new() { FirstName = "Ana", LastName = "López", Skill = 85, ReactionTime = 80, Gender = Gender.Female },
+                new() { FirstName = "Laura", LastName = "Pérez", Skill = 88, ReactionTime = 82, Gender = Gender.Female }
             ]
         };
 
@@ -116,7 +116,7 @@ public class CreateTournamentHandlerTests
             Players =
         [
             new() { Id = existingId },
-            new() { Name = "Caro", Surname = "Y", Skill = 85, ReactionTime = 75, Gender = Gender.Female }
+            new() { FirstName = "Caro", LastName = "Y", Skill = 85, ReactionTime = 75, Gender = Gender.Female }
         ]
         };
 

--- a/tests/Challengers.UnitTests/Challengers.Application/Features/Tournaments/Queries/GetTournamentResult/GetTournamentResultHandlerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Features/Tournaments/Queries/GetTournamentResult/GetTournamentResultHandlerTests.cs
@@ -35,7 +35,7 @@ public class GetTournamentResultHandlerTests
         result.Id.Should().Be(id);
         result.Name.Should().Be("Finalizado");
         result.Gender.Should().Be(Gender.Female);
-        result.Winner.Should().Be(tournament.Winner!.GetFullName());
+        result.Winner.Should().Be(tournament.Winner!.FullName);
     }
 
     [Fact]

--- a/tests/Challengers.UnitTests/Challengers.Application/Validators/CreatePlayerRequestDtoValidatorTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Validators/CreatePlayerRequestDtoValidatorTests.cs
@@ -13,13 +13,13 @@ public class CreatePlayerRequestDtoValidatorTests
     public void Validate_ShouldHaveError_WhenNameIsEmpty()
     {
         // Arrange
-        var model = TestHelper.GetValidMalePlayer() with { Name = "" };
+        var model = TestHelper.GetValidMalePlayer() with { FirstName = "" };
 
         // Act
         var result = _validator.TestValidate(model);
 
         // Assert
-        result.ShouldHaveValidationErrorFor(x => x.Name);
+        result.ShouldHaveValidationErrorFor(x => x.FirstName);
     }
 
     [Fact]

--- a/tests/Challengers.UnitTests/Challengers.Application/Validators/CreateTournamentRequestDtoValidatorTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Validators/CreateTournamentRequestDtoValidatorTests.cs
@@ -58,8 +58,8 @@ public class CreateTournamentRequestDtoValidatorTests
             Gender = Gender.Male,
             Players =
             [
-                new() { Id = duplicatedId, Name = "A", Skill = 80, Strength = 80, Speed = 80, Gender = Gender.Male },
-                new() { Id = duplicatedId, Name = "B", Skill = 85, Strength = 85, Speed = 85, Gender = Gender.Male }
+                new() { Id = duplicatedId, FirstName = "A", Skill = 80, Strength = 80, Speed = 80, Gender = Gender.Male },
+                new() { Id = duplicatedId, FirstName = "B", Skill = 85, Strength = 85, Speed = 85, Gender = Gender.Male }
             ]
         };
 
@@ -80,8 +80,8 @@ public class CreateTournamentRequestDtoValidatorTests
             Gender = Gender.Female,
             Players =
             [
-                new() { Name = "Ana", Surname = "One", Skill = 80, ReactionTime = 85, Gender = Gender.Female },
-                new() { Name = "Laura", Surname = "Two", Skill = 75, ReactionTime = 80, Gender = Gender.Female }
+                new() { FirstName = "Ana", LastName = "One", Skill = 80, ReactionTime = 85, Gender = Gender.Female },
+                new() { FirstName = "Laura", LastName = "Two", Skill = 75, ReactionTime = 80, Gender = Gender.Female }
             ]
         };
 

--- a/tests/Challengers.UnitTests/Challengers.Application/Validators/GetPlayersQueryDtoValidatorTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Validators/GetPlayersQueryDtoValidatorTests.cs
@@ -16,30 +16,30 @@ public class GetPlayersQueryDtoValidatorTests
         // Arrange
         var model = new GetPlayersQueryDto
         {
-            Name = new string('A', 101)
+            FirstName = new string('A', 101)
         };
 
         // Act
         var result = _validator.TestValidate(model);
 
         // Assert
-        result.ShouldHaveValidationErrorFor(x => x.Name);
+        result.ShouldHaveValidationErrorFor(x => x.FirstName);
     }
 
     [Fact]
-    public void Validate_ShouldHaveError_WhenSurnameTooLong()
+    public void Validate_ShouldHaveError_WhenLastNameTooLong()
     {
         // Arrange
         var model = new GetPlayersQueryDto
         {
-            Surname = new string('B', 101)
+            LastName = new string('B', 101)
         };
 
         // Act
         var result = _validator.TestValidate(model);
 
         // Assert
-        result.ShouldHaveValidationErrorFor(x => x.Surname);
+        result.ShouldHaveValidationErrorFor(x => x.LastName);
     }
 
     [Fact]
@@ -64,8 +64,8 @@ public class GetPlayersQueryDtoValidatorTests
         // Arrange
         var model = new GetPlayersQueryDto
         {
-            Name = "Ana",
-            Surname = "Gomez",
+            FirstName = "Ana",
+            LastName = "Gomez",
             Gender = Gender.Female,
             Page = 1,
             PageSize = 10

--- a/tests/Challengers.UnitTests/Challengers.Application/Validators/PlayerDtoValidatorTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Validators/PlayerDtoValidatorTests.cs
@@ -30,32 +30,32 @@ public class PlayerDtoValidatorTests
         var model = new PlayerDto
         {
             Id = Guid.NewGuid(),
-            Name = new string('A', 101)
+            FirstName = new string('A', 101)
         };
 
         // Act
         var result = _validator.TestValidate(model);
 
         // Assert
-        result.ShouldHaveValidationErrorFor(x => x.Name);
+        result.ShouldHaveValidationErrorFor(x => x.FirstName);
     }
 
     [Fact]
-    public void Validate_ShouldHaveError_WhenSurnameTooLong()
+    public void Validate_ShouldHaveError_WhenLastNameTooLong()
     {
         // Arrange
         var model = new PlayerDto
         {
             Id = Guid.NewGuid(),
-            Name = "Test",
-            Surname = new string('B', 101)
+            FirstName = "Test",
+            LastName = new string('B', 101)
         };
 
         // Act
         var result = _validator.TestValidate(model);
 
         // Assert
-        result.ShouldHaveValidationErrorFor(x => x.Surname);
+        result.ShouldHaveValidationErrorFor(x => x.LastName);
     }
 
     [Fact]
@@ -82,8 +82,8 @@ public class PlayerDtoValidatorTests
         var model = new PlayerDto
         {
             Id = Guid.NewGuid(),
-            Name = "Carlos",
-            Surname = "Gomez",
+            FirstName = "Carlos",
+            LastName = "Gomez",
             Skill = 90,
             Gender = Gender.Male
         };

--- a/tests/Challengers.UnitTests/Challengers.Application/Validators/PlayerReferenceOrCreateValidatorTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Application/Validators/PlayerReferenceOrCreateValidatorTests.cs
@@ -14,7 +14,7 @@ public class PlayerReferenceOrCreateValidatorTests
     public void Validate_ShouldHaveError_WhenIdIsEmpty()
     {
         // Arrange
-        var model = new PlayerDto { Id = Guid.Empty, Name = "Test" };
+        var model = new PlayerDto { Id = Guid.Empty, FirstName = "Test" };
 
         // Act
         var result = _validator.TestValidate(model);
@@ -42,8 +42,8 @@ public class PlayerReferenceOrCreateValidatorTests
         // Arrange
         var model = new PlayerDto
         {
-            Name = "",
-            Surname = "",
+            FirstName = "",
+            LastName = "",
             Skill = 200,
             Gender = Gender.Male,
             Strength = 120,
@@ -64,8 +64,8 @@ public class PlayerReferenceOrCreateValidatorTests
         // Arrange
         var model = new PlayerDto
         {
-            Name = "Lucía",
-            Surname = "Martínez",
+            FirstName = "Lucía",
+            LastName = "Martínez",
             Skill = 80,
             ReactionTime = 85,
             Gender = Gender.Female,

--- a/tests/Challengers.UnitTests/Challengers.Domain/Entities/PlayerTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Domain/Entities/PlayerTests.cs
@@ -44,14 +44,14 @@ public class PlayerTests
     }
 
     [Theory]
-    [InlineData(null, "Surname")]
+    [InlineData(null, "LastName")]
     [InlineData("Name", null)]
-    [InlineData("", "Surname")]
+    [InlineData("", "LastName")]
     [InlineData("Name", "")]
-    public void FemalePlayer_ShouldThrow_WhenNameOrSurnameInvalid(string? name, string? surname)
+    public void FemalePlayer_ShouldThrow_WhenNameOrLastNameInvalid(string? name, string? lastname)
     {
         // Arrange & Act
-        Action act = () => new FemalePlayer(name!, surname!, 80, 80);
+        Action act = () => new FemalePlayer(name!, lastname!, 80, 80);
         // Assert
         act.Should().Throw<ArgumentException>();
     }
@@ -100,18 +100,18 @@ public class PlayerTests
         // Act
         player.SetName("Laura");
         // Assert   
-        player.Name.Should().Be("Laura");
+        player.FirstName.Should().Be("Laura");
     }
 
     [Fact]
-    public void SetSurname_ShouldUpdatePlayerSurname()
+    public void SetLastName_ShouldUpdatePlayerLastName()
     {
         // Arrange
         var player = new FemalePlayer("Ana", "Perez", 80, 80);
         // Act
-        player.SetSurname("Gomez");
+        player.SetLastName("Gomez");
         // Assert
-        player.Surname.Should().Be("Gomez");
+        player.LastName.Should().Be("Gomez");
     }
 
     [Fact]
@@ -131,7 +131,7 @@ public class PlayerTests
         // Arrange
         var player = new FemalePlayer("Ana", "Perez", 80, 80);
         // Act
-        var fullName = player.GetFullName();
+        var fullName = player.FullName;
         // Assert
         fullName.Should().Be("Ana Perez");
     }

--- a/tests/Challengers.UnitTests/Challengers.Domain/Entities/TournamentTests.cs
+++ b/tests/Challengers.UnitTests/Challengers.Domain/Entities/TournamentTests.cs
@@ -172,8 +172,8 @@ public class TournamentTests
         tournament.IsCompleted.Should().BeTrue();
         tournament.Matches.Should().HaveCount(7);
         tournament.Winner.Should().NotBeNull();
-        tournament.Winner!.Name.Should().Be("Player");
-        tournament.Winner!.Surname.Should().Be("1");
+        tournament.Winner!.FirstName.Should().Be("Player");
+        tournament.Winner!.LastName.Should().Be("1");
     }
 
     [Theory]

--- a/tests/Challengers.UnitTests/Helpers/TestHelper.cs
+++ b/tests/Challengers.UnitTests/Helpers/TestHelper.cs
@@ -41,8 +41,8 @@ public static class TestHelper
         return [.. Enumerable.Range(1, count)
             .Select(i => new PlayerDto
             {
-                Name = $"Player{i}",
-                Surname = $"Surname{i}",
+                FirstName = $"Player{i}",
+                LastName = $"LastName{i}",
                 Skill = 80,
                 Strength = 80,
                 Speed = 80,
@@ -53,8 +53,8 @@ public static class TestHelper
     public static CreatePlayerRequestDto GetValidMalePlayer() =>
         new()
         {
-            Name = "Juan",
-            Surname = "Pérez",
+            FirstName = "Juan",
+            LastName = "Pérez",
             Gender = Gender.Male,
             Skill = 80,
             Strength = 85,
@@ -65,8 +65,8 @@ public static class TestHelper
     public static CreatePlayerRequestDto GetValidFemalePlayer() =>
         new()
         {
-            Name = "Ana",
-            Surname = "Gómez",
+            FirstName = "Ana",
+            LastName = "Gómez",
             Gender = Gender.Female,
             Skill = 75,
             ReactionTime = 85,
@@ -78,7 +78,7 @@ public static class TestHelper
     {
         var _client = client;
         await _client.PostAsJsonAsync("/api/players", dto);
-        var response = await _client.GetAsync($"/api/players?name={dto.Name}");
+        var response = await _client.GetAsync($"/api/players?firstname={dto.FirstName}");
         var raw = await response.Content.ReadAsStringAsync();
         var paged = JsonSerializer.Deserialize<PagedResultDto<PlayerDto>>(raw, _jsonSerializerOptions);
         return paged!.Items[0].Id;


### PR DESCRIPTION

This pull request refactors the entire codebase to replace the `Name` and `Surname` properties with `FirstName` and `LastName` respectively, for better clarity and consistency.

### Changes included:
- **Domain:** Renamed properties in `Player`, `MalePlayer`, and `FemalePlayer`.
- **Application layer:**
  - Updated all DTOs (`CreatePlayerRequestDto`, `UpdatePlayerRequestDto`, `PlayerDto`, `PlayerExcelDto`, etc.).
  - Modified all validators and handlers to use `FirstName` and `LastName`.
- **Infrastructure:**
  - Renamed database columns via EF Core migration `UseFirstNameAndLastName`.
  - Updated entity configuration and query filters.
- **Tests:**
  - Refactored all unit and integration tests accordingly.
- **Localization:**
  - Updated resource keys and messages in `.resx` files (EN/ES).

### Notes:
- This PR introduces a new EF Core migration: `UseFirstNameAndLastName`
- This is a **breaking change** that affects API contracts and database schema.
- Clients consuming the API must update request/response formats accordingly.
- This refactor sets a consistent naming convention ahead of new features like Excel import.
